### PR TITLE
feat: set ipfs and minio URLs

### DIFF
--- a/packages/cli/src/lib/cluster-manager.ts
+++ b/packages/cli/src/lib/cluster-manager.ts
@@ -4,6 +4,21 @@ type GraphSvc = { gqlUrl: string; name: string; uniqueName: string };
 type PortalSvc = { gqlUrl: string; restUrl: string; name: string; uniqueName: string };
 type HasuraSvc = { gqlUrl: string; name: string; adminSecret: string; uniqueName: string };
 type UserWalletSvc = { name: string; uniqueName: string };
+type IpfsStorageSvc = {
+  apiUrl: string;
+  pinningUrl: string;
+  name: string;
+  uniqueName: string;
+};
+
+type MinioStorageSvc = {
+  s3Url: string;
+  accessKey: string;
+  secretKey: string;
+  name: string;
+  uniqueName: string;
+};
+
 type CustomDeploymentSvc = {
   id: string;
   name: string;
@@ -22,6 +37,8 @@ type Appl = {
   hasuras: HasuraSvc[]; // List of Hasura services
   nodes: NodeSvc[]; // List of Node services
   customDeployments: CustomDeploymentSvc[]; // List of Custom Deployment services
+  ipfsStorages: IpfsStorageSvc[]; // List of IPFS Storage services
+  minioStorages: MinioStorageSvc[]; // List of Minio Storage services
   userWallets: UserWalletSvc[]; // List of User Wallet services
 };
 

--- a/packages/config/src/schemas.ts
+++ b/packages/config/src/schemas.ts
@@ -13,6 +13,9 @@ const ApplicationConfigSchema = z.object({
   thegraphGql: z.string().url().optional(),
   subgraphName: z.string().optional(),
   hasuraGql: z.string().url().optional(),
+  ipfs: z.string().url().optional(),
+  ipfsPinning: z.string().url().optional(),
+  minio: z.string().url().optional(),
   nodeJsonRpc: z.string().url().optional(),
   nodeJsonRpcDeploy: z.string().url().optional(),
   customDeploymentId: z.string().optional(),
@@ -50,6 +53,8 @@ export const EnvSchema = z.object({
   SETTLEMINT_HASURA_GQL_ADMIN_SECRET: z.string().optional(),
   SETTLEMINT_APP_URL: z.string().url().optional(),
   SETTLEMINT_AUTH_SECRET: z.string().min(32).optional(),
+  SETTLEMINT_MINIO_ACCESS_KEY: z.string().optional(),
+  SETTLEMINT_MINIO_SECRET_KEY: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce options to configure IPFS and Minio storage URLs in the CLI connect command, and update the application configuration schema to support these new storage options.

New Features:
- Add support for specifying IPFS and Minio storage URLs in the connect command, allowing users to configure these storage options via command-line options or environment variables.

Enhancements:
- Extend the application configuration schema to include optional fields for IPFS and Minio URLs, enabling more flexible storage configurations.

<!-- Generated by sourcery-ai[bot]: end summary -->