### PR TITLE
feat: add client side codegen

### DIFF
--- a/packages/cli/src/commands/codegen/codegen-hasura.ts
+++ b/packages/cli/src/commands/codegen/codegen-hasura.ts
@@ -21,7 +21,7 @@ export async function codegenHasura(env: DotEnv) {
     },
   });
 
-  const clientTemplate = `import { createServerHasuraClient } from "@settlemint/sdk-hasura";
+  const serverSideTemplate = `import { createServerHasuraClient } from "@settlemint/sdk-hasura";
 import type { introspection } from "../../hasura-env.d.ts";
 
 export const { client: hasuraClient, graphql: hasuraGraphql } = createServerHasuraClient<{
@@ -37,5 +37,21 @@ export const { client: hasuraClient, graphql: hasuraGraphql } = createServerHasu
   adminSecret: process.env.SETTLEMINT_HASURA_ADMIN_SECRET!,
 });`;
 
-  await writeTemplate(clientTemplate, "/lib/settlemint", "hasura.ts");
+  await writeTemplate(serverSideTemplate, "/lib/settlemint", "hasura.ts");
+
+  const clientSideTemplate = `import { createHasuraClient } from "@settlemint/sdk-hasura";
+import type { introspection } from "../../hasura-env.d.ts";
+
+export const { client: hasuraClient, graphql: hasuraGraphql } = createHasuraClient<{
+  introspection: introspection;
+  disableMasking: true;
+  scalars: {
+    DateTime: Date;
+    JSON: Record<string, unknown>;
+  };
+}>({
+  instance: "/proxy/hasura/graphql",
+});`;
+
+  await writeTemplate(clientSideTemplate, "/lib/settlemint/clientside", "hasura.ts");
 }

--- a/packages/cli/src/commands/codegen/codegen-the-graph-fallback.ts
+++ b/packages/cli/src/commands/codegen/codegen-the-graph-fallback.ts
@@ -19,7 +19,7 @@ export async function codegenTheGraphFallback(env: DotEnv) {
     },
   });
 
-  const clientTemplate = `import { createServerTheGraphClient } from "@settlemint/sdk-thegraph";
+  const serverSideTemplate = `import { createServerTheGraphClient } from "@settlemint/sdk-thegraph";
 import type { introspection } from "../../the-graph-fallback-env.d.ts";
 
 export const { client: theGraphFallbackClient, graphql: theGraphFallbackGraphql } = createServerTheGraphClient<{
@@ -34,5 +34,21 @@ export const { client: theGraphFallbackClient, graphql: theGraphFallbackGraphql 
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
 });`;
 
-  await writeTemplate(clientTemplate, "/lib/settlemint", "the-graph-fallback.ts");
+  await writeTemplate(serverSideTemplate, "/lib/settlemint", "the-graph-fallback.ts");
+
+  const clientSideTemplate = `import { createTheGraphClient } from "@settlemint/sdk-thegraph";
+  import type { introspection } from "../../the-graph-fallback-env.d.ts";
+
+  export const { client: theGraphFallbackClient, graphql: theGraphFallbackGraphql } = createTheGraphClient<{
+    introspection: introspection;
+    disableMasking: true;
+    scalars: {
+      DateTime: Date;
+      JSON: Record<string, unknown>;
+    };
+  }>({
+    instance: "/proxy/thegraph-fallback/graphql",
+  });`;
+
+  await writeTemplate(clientSideTemplate, "/lib/settlemint/clientside", "the-graph-fallback.ts");
 }

--- a/packages/cli/src/commands/codegen/codegen-the-graph.ts
+++ b/packages/cli/src/commands/codegen/codegen-the-graph.ts
@@ -19,7 +19,7 @@ export async function codegenTheGraph(env: DotEnv) {
     },
   });
 
-  const clientTemplate = `import { createServerTheGraphClient } from "@settlemint/sdk-thegraph";
+  const serverSideTemplate = `import { createServerTheGraphClient } from "@settlemint/sdk-thegraph";
 import type { introspection } from "../../the-graph-env.d.ts";
 
 export const { client: theGraphClient, graphql: theGraphGraphql } = createServerTheGraphClient<{
@@ -34,5 +34,21 @@ export const { client: theGraphClient, graphql: theGraphGraphql } = createServer
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
 });`;
 
-  await writeTemplate(clientTemplate, "/lib/settlemint", "the-graph.ts");
+  await writeTemplate(serverSideTemplate, "/lib/settlemint", "the-graph.ts");
+
+  const clientSideTemplate = `import { createTheGraphClient } from "@settlemint/sdk-thegraph";
+  import type { introspection } from "../../the-graph-env.d.ts";
+
+  export const { client: theGraphClient, graphql: theGraphGraphql } = createTheGraphClient<{
+    introspection: introspection;
+    disableMasking: true;
+    scalars: {
+      DateTime: Date;
+      JSON: Record<string, unknown>;
+    };
+  }>({
+    instance: "/proxy/thegraph/graphql",
+  });`;
+
+  await writeTemplate(clientSideTemplate, "/lib/settlemint/clientside", "the-graph.ts");
 }


### PR DESCRIPTION
## Summary by Sourcery

Add client-side code generation capabilities for Hasura, The Graph, and The Graph Fallback, enabling the generation of client-side templates in addition to server-side templates.

New Features:
- Introduce client-side code generation for Hasura, The Graph, and The Graph Fallback, allowing the creation of client-side templates alongside existing server-side templates.