### PR TITLE
feat(cli): Update custom deployment command with wait option

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import { connectCommand } from "@/commands/connect";
 import { Command } from "@commander-js/extra-typings";
 import { ascii, cancel } from "@settlemint/sdk-utils/terminal";
 import pkg from "../package.json";
+import { platformCommand } from "./commands/platform";
 
 ascii();
 
@@ -39,6 +40,7 @@ sdkcli
 // Add commands to the CLI
 sdkcli.addCommand(connectCommand());
 sdkcli.addCommand(codegenCommand());
+sdkcli.addCommand(platformCommand());
 
 /**
  * Parses command line arguments and executes the appropriate command.

--- a/packages/cli/src/commands/platform.ts
+++ b/packages/cli/src/commands/platform.ts
@@ -1,4 +1,4 @@
-import { customDeploymentsCommand } from "@/commands/platform/custom-deployments";
+import { updateCommand } from "@/commands/platform/update";
 import { Command } from "@commander-js/extra-typings";
 
 /**
@@ -9,8 +9,5 @@ import { Command } from "@commander-js/extra-typings";
  * @returns {Command} The configured 'platform' command
  */
 export function platformCommand(): Command {
-  return new Command("platform")
-    .option("--prod", "Connect to your production environment")
-    .description("Manage SettleMint platform resources")
-    .addCommand(customDeploymentsCommand());
+  return new Command("platform").description("Manage SettleMint platform resources").addCommand(updateCommand());
 }

--- a/packages/cli/src/commands/platform/custom-deployments/update.ts
+++ b/packages/cli/src/commands/platform/custom-deployments/update.ts
@@ -1,3 +1,4 @@
+import { waitForCompletion } from "@/commands/platform/utils/wait-for-completion";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
@@ -13,34 +14,36 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
  * @returns {Command} The configured 'connect' command
  */
 export function customDeploymentsUpdateCommand(): Command<[id: string, tag: string], { prod?: boolean }> {
-  return (
-    new Command("update")
-      .alias("patch")
-      .argument("<id>", "The ID of the custom deployment to update")
-      .argument("<tag>", "The tag to update the custom deployment to")
-      .option("--prod", "Connect to your production environment")
-      // Set the command description
-      .description("Update a custom deployment in the SettleMint platform")
-      // Define the action to be executed when the command is run
-      .action(async (id, tag, { prod }) => {
-        intro("Updating custom deployment in the SettleMint platform");
+  return new Command("custom-deployment")
+    .alias("custom-deployments")
+    .alias("cd")
+    .argument("<id>", "The ID of the custom deployment to update")
+    .argument("<tag>", "The tag to update the custom deployment to")
+    .option("--prod", "Connect to your production environment")
+    .option("--wait", "Wait for the custom deployment to be redeployed")
+    .description("Update a custom deployment in the SettleMint platform")
+    .action(async (id, tag, { prod, wait }) => {
+      intro("Updating custom deployment in the SettleMint platform");
 
-        const env: DotEnv = await loadEnv(true, !!prod);
+      const env: DotEnv = await loadEnv(true, !!prod);
 
-        const settlemint = createSettleMintClient({
-          accessToken: env.SETTLEMINT_ACCESS_TOKEN,
-          instance: env.SETTLEMINT_INSTANCE,
-        });
+      const settlemint = createSettleMintClient({
+        accessToken: env.SETTLEMINT_ACCESS_TOKEN,
+        instance: env.SETTLEMINT_INSTANCE,
+      });
 
-        const customDeployment = await spinner({
-          startMessage: "Updating custom deployment",
-          task: async () => {
-            return settlemint.customDeployment.update(id, tag);
-          },
-          stopMessage: "Custom deployment updated",
-        });
+      const customDeployment = await spinner({
+        startMessage: "Updating custom deployment",
+        task: async () => {
+          return settlemint.customDeployment.update(id, tag);
+        },
+        stopMessage: "Custom deployment updated",
+      });
 
-        outro(`${customDeployment.name} updated to ${tag}, redeploying now...`);
-      })
-  );
+      if (wait) {
+        await waitForCompletion(settlemint, "customDeployment", customDeployment.id);
+      }
+
+      outro(`${customDeployment.name} updated to ${tag}`);
+    });
 }

--- a/packages/cli/src/commands/platform/update.ts
+++ b/packages/cli/src/commands/platform/update.ts
@@ -1,5 +1,5 @@
 import { Command } from "@commander-js/extra-typings";
-import { customDeploymentsUpdateCommand } from "./custom-deployments/edit";
+import { customDeploymentsUpdateCommand } from "./custom-deployments/update";
 
 /**
  * Creates and returns the 'custom-deployments' command for the SettleMint SDK.
@@ -8,10 +8,9 @@ import { customDeploymentsUpdateCommand } from "./custom-deployments/edit";
  *
  * @returns {Command} The configured 'custom-deployments' command
  */
-export function customDeploymentsCommand(): Command {
-  return new Command("custom-deployments")
-    .alias("cd")
-    .option("--prod", "Connect to your production environment")
-    .description("Manage custom deployments in the SettleMint platform")
+export function updateCommand(): Command {
+  return new Command("update")
+    .alias("u")
+    .description("Update a resource in the SettleMint platform")
     .addCommand(customDeploymentsUpdateCommand());
 }

--- a/packages/cli/src/commands/platform/utils/wait-for-completion.ts
+++ b/packages/cli/src/commands/platform/utils/wait-for-completion.ts
@@ -1,0 +1,37 @@
+import type { SettlemintClient } from "@settlemint/sdk-js";
+import type { Id } from "@settlemint/sdk-utils/validation";
+
+/**
+ * Waits for a resource to complete or fails after 10 minutes.
+ * @param settlemint - The SettlemintClient instance
+ * @param type - The type of resource to check
+ * @param id - The ID of the resource
+ * @returns A promise that resolves to true if the resource completes, or rejects if it times out
+ * @throws Error if the operation times out after 10 minutes
+ */
+export async function waitForCompletion(
+  settlemint: SettlemintClient,
+  type: keyof SettlemintClient,
+  id: Id,
+): Promise<boolean> {
+  const startTime = Date.now();
+  const timeoutDuration = 10 * 60 * 1000; // 10 minutes in milliseconds
+
+  while (true) {
+    const resource = await settlemint[type].read(id);
+
+    if (type === "workspace") {
+      return true;
+    }
+
+    if ((resource as { status: string }).status === "COMPLETED") {
+      return true;
+    }
+
+    if (Date.now() - startTime > timeoutDuration) {
+      throw new Error(`Operation timed out after 10 minutes for ${type} with id ${id}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+}


### PR DESCRIPTION
Added option to wait for deployment to be redeployed after updating.
Updated custom deployment command with wait option for better control.

## Summary by Sourcery

Add a '--wait' option to the custom deployment update command in the CLI to enable waiting for redeployment completion. Refactor the command structure for improved clarity and usability.

New Features:
- Introduce a new '--wait' option in the custom deployment update command to allow users to wait for the deployment to be redeployed.

Enhancements:
- Refactor the CLI command structure by renaming and reorganizing commands for better clarity and usability.