### PR TITLE
fix: minio region

### DIFF
--- a/packages/minio/src/minio.ts
+++ b/packages/minio/src/minio.ts
@@ -34,6 +34,7 @@ export function createServerMinioClient(options: ServerClientOptions): { client:
       endPoint: new URL(validatedOptions.instance).host,
       accessKey: validatedOptions.accessKey,
       secretKey: validatedOptions.secretKey,
+      region: "eu-central-1",
     }),
   };
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set the MinIO client region to 'eu-central-1' to fix region-related issues.