### PR TITLE
fix: graphql url

### DIFF
--- a/packages/js/src/settlemint.ts
+++ b/packages/js/src/settlemint.ts
@@ -85,7 +85,7 @@ export function createSettleMintClient(options: ClientOptions): SettlemintClient
   const validatedOptions = validate(ClientOptionsSchema, options);
 
   const baseUrl = new URL(validatedOptions.instance);
-  const gqlClient = new GraphQLClient(`${baseUrl.origin}${baseUrl.pathname}/api/graphql`, {
+  const gqlClient = new GraphQLClient(`${baseUrl.origin}${baseUrl.pathname}api/graphql`, {
     headers: {
       "x-auth-token": validatedOptions.accessToken,
     },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the GraphQL endpoint URL by removing an extra slash in the path.