### PR TITLE
fix: publish to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,6 @@ jobs:
       - name: Load secrets
         uses: 1password/load-secrets-action@v2
         env:
-          DOCKERHUB_USER: op://platform/dockerhub/username
-          DOCKERHUB_PASS: op://platform/dockerhub/credential
           NPM_TOKEN: op://platform/npmjs/credential
 
       - name: Inject slug/short variables
@@ -133,7 +131,7 @@ jobs:
       - name: Login to npm
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Run tests and checks
         run: bunx turbo format lint build attw publint registry test:coverage publish-npm --env-mode=loose
@@ -191,13 +189,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USER }}
-          password: ${{ env.DOCKERHUB_PASS }}
 
       - name: Generate Docker metadata
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary by Sourcery

Fix the npm publishing process by correcting the NPM_TOKEN usage and remove unnecessary DockerHub login steps from the CI workflow.

Bug Fixes:
- Fix the npm login process by using the environment variable for NPM_TOKEN instead of secrets.

CI:
- Remove DockerHub login steps from the CI workflow.