### PR TITLE
fix: skip env check on custom deployment update command

### DIFF
--- a/sdk/cli/src/commands/platform/custom-deployments/update.ts
+++ b/sdk/cli/src/commands/platform/custom-deployments/update.ts
@@ -34,7 +34,7 @@ export function customDeploymentsUpdateCommand(): Command<[tag: string], { prod?
 
       const customDeploymentId = id ?? env.SETTLEMINT_CUSTOM_DEPLOYMENT;
       if (!customDeploymentId) {
-        throw new Error("No custom deployment configured");
+        throw new Error("No custom deployment ID specified. Please provide it either via the --id flag or by setting the SETTLEMINT_CUSTOM_DEPLOYMENT environment variable");
       }
 
       const accessToken = await accessTokenPrompt(env, true);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Skip environment check when updating a custom deployment if the deployment ID is provided as an option.