### PR TITLE
feat: create a new access token and use two levels of settlemint clients to ensure separation

### DIFF
--- a/sdk/cli/src/commands/connect/aat.prompt.ts
+++ b/sdk/cli/src/commands/connect/aat.prompt.ts
@@ -1,6 +1,9 @@
 import confirm from "@inquirer/confirm";
+import input from "@inquirer/input";
 import password from "@inquirer/password";
+import type { Application, SettlemintClient } from "@settlemint/sdk-js";
 import { ApplicationAccessTokenSchema, type DotEnv, validate } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
 /**
  * Prompts the user for the access token of their SettleMint application.
  * If the access token is already present in the environment variables and valid,
@@ -15,7 +18,12 @@ import { ApplicationAccessTokenSchema, type DotEnv, validate } from "@settlemint
  * const accessToken = await accessTokenPrompt(env);
  * console.log(accessToken); // Output: your-access-token or user input
  */
-export async function applicationAccessTokenPrompt(env: Partial<DotEnv>, accept: boolean): Promise<string> {
+export async function applicationAccessTokenPrompt(
+  env: Partial<DotEnv>,
+  application: Application,
+  settlemint: SettlemintClient,
+  accept: boolean,
+): Promise<string> {
   const defaultAccessToken = env.SETTLEMINT_ACCESS_TOKEN;
   const defaultPossible = accept && defaultAccessToken;
 
@@ -30,6 +38,80 @@ export async function applicationAccessTokenPrompt(env: Partial<DotEnv>, accept:
     });
     if (keep) {
       return defaultAccessToken;
+    }
+  }
+
+  const create = await confirm({
+    message: "Do you want to create a new application access token?",
+    default: false,
+  });
+
+  if (create) {
+    const name = await input({
+      message: "How would you like to name this application access token?",
+      default: `SettleMint CLI (${Date.now()}${process.env.USER ? ` ${process.env.USER}` : ""})`,
+      required: true,
+      validate(value) {
+        try {
+          validate(z.string(), value);
+          return true;
+        } catch (error) {
+          return "Invalid token name";
+        }
+      },
+    });
+
+    const aat = await settlemint.applicationAccessToken.create({
+      applicationId: application.id,
+      name,
+      blockchainNetworkScope: {
+        type: "ALL",
+        values: [],
+      },
+      blockchainNodeScope: {
+        type: "ALL",
+        values: [],
+      },
+      customDeploymentScope: {
+        type: "ALL",
+        values: [],
+      },
+      insightsScope: {
+        type: "ALL",
+        values: [],
+      },
+      integrationScope: {
+        type: "ALL",
+        values: [],
+      },
+      loadBalancerScope: {
+        type: "ALL",
+        values: [],
+      },
+      middlewareScope: {
+        type: "ALL",
+        values: [],
+      },
+      privateKeyScope: {
+        type: "ALL",
+        values: [],
+      },
+      smartContractSetScope: {
+        type: "ALL",
+        values: [],
+      },
+      storageScope: {
+        type: "ALL",
+        values: [],
+      },
+      validityPeriod: "NONE",
+    });
+
+    try {
+      validate(ApplicationAccessTokenSchema, aat);
+      return aat;
+    } catch (error) {
+      // invalid, ask for it
     }
   }
 

--- a/sdk/cli/src/commands/platform/common/create-command.ts
+++ b/sdk/cli/src/commands/platform/common/create-command.ts
@@ -1,4 +1,3 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { writeEnvSpinner } from "@/commands/connect/write-env.spinner";
 import { type CommandExample, createExamples } from "@/commands/platform/utils/create-examples";
@@ -8,7 +7,7 @@ import { Command } from "@commander-js/extra-typings";
 import { type SettlemintClient, createSettleMintClient } from "@settlemint/sdk-js";
 import { type DotEnv, capitalizeFirstLetter } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { intro, note, outro, spinner } from "@settlemint/sdk-utils/terminal";
+import { cancel, intro, note, outro, spinner } from "@settlemint/sdk-utils/terminal";
 import isInCi from "is-in-ci";
 import type { ResourceType } from "./resource-type";
 
@@ -73,7 +72,10 @@ export function getCreateCommand({
     const autoAccept = !!acceptDefaults || isInCi;
     const env: Partial<DotEnv> = await loadEnv(false, !!prod);
 
-    const accessToken = await applicationAccessTokenPrompt(env, autoAccept);
+    const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+    if (!accessToken) {
+      cancel("No access token found, please run `settlemint connect` to connect to your instance");
+    }
     const instance = await instancePrompt(env, autoAccept);
     const settlemint = createSettleMintClient({
       accessToken,

--- a/sdk/cli/src/commands/platform/common/delete-command.ts
+++ b/sdk/cli/src/commands/platform/common/delete-command.ts
@@ -1,4 +1,3 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { writeEnvSpinner } from "@/commands/connect/write-env.spinner";
 import { waitForCompletion } from "@/commands/platform/utils/wait-for-completion";
@@ -7,7 +6,7 @@ import { Command } from "@commander-js/extra-typings";
 import { type SettlemintClient, createSettleMintClient } from "@settlemint/sdk-js";
 import { capitalizeFirstLetter } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { intro, note, outro, spinner } from "@settlemint/sdk-utils/terminal";
+import { cancel, intro, note, outro, spinner } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 import { deleteConfirmationPrompt } from "../prompts/delete-confirmation.prompt";
@@ -75,7 +74,10 @@ ${createExamples([
       const autoAccept = !!acceptDefaults || isInCi;
       const env: Partial<DotEnv> = await loadEnv(false, !!prod);
 
-      const accessToken = await applicationAccessTokenPrompt(env, autoAccept);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, autoAccept);
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/common/restart-command.ts
+++ b/sdk/cli/src/commands/platform/common/restart-command.ts
@@ -1,4 +1,3 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { waitForCompletion } from "@/commands/platform/utils/wait-for-completion";
 import { sanitizeCommandName } from "@/utils/sanitize-command-name";
@@ -6,7 +5,7 @@ import { Command } from "@commander-js/extra-typings";
 import { type SettlemintClient, createSettleMintClient } from "@settlemint/sdk-js";
 import { capitalizeFirstLetter } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
+import { cancel, intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 import { createExamples } from "../utils/create-examples";
@@ -64,7 +63,10 @@ ${createExamples([
       const autoAccept = !!acceptDefaults || isInCi;
       const env: Partial<DotEnv> = await loadEnv(false, !!prod);
 
-      const accessToken = await applicationAccessTokenPrompt(env, autoAccept);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, autoAccept);
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/custom-deployments/update.ts
+++ b/sdk/cli/src/commands/platform/custom-deployments/update.ts
@@ -1,10 +1,9 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { waitForCompletion } from "@/commands/platform/utils/wait-for-completion";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
+import { cancel, intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 /**
@@ -39,7 +38,10 @@ export function customDeploymentsUpdateCommand(): Command<[tag: string], { prod?
         );
       }
 
-      const accessToken = await applicationAccessTokenPrompt(env, true);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, true);
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/utils/wait-for-completion.ts
+++ b/sdk/cli/src/commands/platform/utils/wait-for-completion.ts
@@ -35,6 +35,11 @@ export async function waitForCompletion({
     return true;
   }
 
+  const service = settlemint[serviceType];
+  if (!service || !("read" in service)) {
+    throw new Error(`Service ${serviceType} does not support status checking`);
+  }
+
   return spinner({
     startMessage: `Waiting for ${type} to be ${getActionLabel(action)}`,
     stopMessage: `Waiting for ${type} to be ${getActionLabel(action)}`,
@@ -43,7 +48,7 @@ export async function waitForCompletion({
 
       while (true) {
         try {
-          const resource = await settlemint[serviceType].read(id);
+          const resource = await service.read(id);
 
           if (resource.status === "COMPLETED") {
             note(`${capitalizeFirstLetter(type)} is ${getActionLabel(action)}`);

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
@@ -1,4 +1,3 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { addressPrompt } from "@/commands/smart-contract-set/prompts/address.prompt";
 import { deploymentIdPrompt } from "@/commands/smart-contract-set/prompts/deployment-id.prompt";
@@ -31,7 +30,10 @@ export function hardhatDeployRemoteCommand() {
       throw new ServiceNotConfiguredError("Blockchain node");
     }
 
-    const accessToken = await applicationAccessTokenPrompt(env, true);
+    const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+    if (!accessToken) {
+      cancel("No access token found, please run `settlemint connect` to connect to your instance");
+    }
     const instance = await instancePrompt(env, true);
     const settlemint = createSettleMintClient({
       accessToken,

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
@@ -1,9 +1,9 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { ServiceNotConfiguredError } from "@/error/serviceNotConfiguredError";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { executeCommand, getPackageManagerExecutable, loadEnv } from "@settlemint/sdk-utils";
+import { cancel } from "@settlemint/sdk-utils/terminal";
 
 export function hardhatScriptRemoteCommand() {
   const build = new Command("remote")
@@ -18,7 +18,10 @@ export function hardhatScriptRemoteCommand() {
       throw new ServiceNotConfiguredError("Blockchain node");
     }
 
-    const accessToken = await applicationAccessTokenPrompt(env, true);
+    const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+    if (!accessToken) {
+      cancel("No access token found, please run `settlemint connect` to connect to your instance");
+    }
     const instance = await instancePrompt(env, true);
     const settlemint = createSettleMintClient({
       accessToken,

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/build.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/build.ts
@@ -1,8 +1,8 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { executeCommand, getPackageManagerExecutable, loadEnv } from "@settlemint/sdk-utils";
+import { cancel } from "@settlemint/sdk-utils/terminal";
 import isInCi from "is-in-ci";
 import { isGenerated } from "./utils/is-generated";
 import { subgraphSetup } from "./utils/setup";
@@ -17,7 +17,10 @@ export function subgraphBuildCommand() {
       const autoAccept = !!acceptDefaults || isInCi;
       const env = await loadEnv(false, !!prod);
 
-      const accessToken = await applicationAccessTokenPrompt(env, true);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, true);
       const settlemintClient = createSettleMintClient({
         accessToken,

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/codegen.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/codegen.ts
@@ -1,8 +1,8 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { executeCommand, getPackageManagerExecutable, loadEnv } from "@settlemint/sdk-utils";
+import { cancel } from "@settlemint/sdk-utils/terminal";
 import isInCi from "is-in-ci";
 import { isGenerated } from "./utils/is-generated";
 import { subgraphSetup } from "./utils/setup";
@@ -17,7 +17,10 @@ export function subgraphCodegenCommand() {
       const autoAccept = !!acceptDefaults || isInCi;
       const env = await loadEnv(false, !!prod);
 
-      const accessToken = await applicationAccessTokenPrompt(env, true);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, true);
       const settlemintClient = createSettleMintClient({
         accessToken,

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
@@ -1,4 +1,3 @@
-import { applicationAccessTokenPrompt } from "@/commands/connect/aat.prompt";
 import { instancePrompt } from "@/commands/connect/instance.prompt";
 import {
   getSubgraphConfig,
@@ -24,7 +23,10 @@ export function subgraphDeployCommand() {
       const autoAccept = !!acceptDefaults || isInCi;
       const env = await loadEnv(false, !!prod);
 
-      const accessToken = await applicationAccessTokenPrompt(env, true);
+      const accessToken = env.SETTLEMINT_ACCESS_TOKEN;
+      if (!accessToken) {
+        cancel("No access token found, please run `settlemint connect` to connect to your instance");
+      }
       const instance = await instancePrompt(env, true);
       const settlemintClient = createSettleMintClient({
         accessToken,

--- a/sdk/js/src/graphql/application-access-tokens.ts
+++ b/sdk/js/src/graphql/application-access-tokens.ts
@@ -1,0 +1,36 @@
+import type { ClientOptions } from "@/helpers/client-options.schema.js";
+import { type VariablesOf, graphql } from "@/helpers/graphql.js";
+import type { GraphQLClient } from "graphql-request";
+
+const createApplicationAccessToken = graphql(
+  `
+    mutation CreateApplicationAccessToken($applicationId: ID!, $blockchainNetworkScope: BlockchainNetworkScopeInputType!, $blockchainNodeScope: BlockchainNodeScopeInputType!, $customDeploymentScope: CustomDeploymentScopeInputType!, $insightsScope: InsightsScopeInputType!, $integrationScope: IntegrationScopeInputType!, $loadBalancerScope: LoadBalancerScopeInputType!, $middlewareScope: MiddlewareScopeInputType!, $name: String!, $privateKeyScope: PrivateKeyScopeInputType!, $smartContractSetScope: SmartContractSetScopeInputType!, $storageScope: StorageScopeInputType!, $validityPeriod: AccessTokenValidityPeriod!) {
+      createApplicationAccessToken(applicationId: $applicationId, blockchainNetworkScope: $blockchainNetworkScope, blockchainNodeScope: $blockchainNodeScope, customDeploymentScope: $customDeploymentScope, insightsScope: $insightsScope, integrationScope: $integrationScope, loadBalancerScope: $loadBalancerScope, middlewareScope: $middlewareScope, name: $name, privateKeyScope: $privateKeyScope, smartContractSetScope: $smartContractSetScope, storageScope: $storageScope, validityPeriod: $validityPeriod) {
+        token
+      }
+    }
+  `,
+  [],
+);
+
+export type CreateApplicationAccessTokenArgs = VariablesOf<typeof createApplicationAccessToken>;
+
+/**
+ * Creates a new application.
+ *
+ * @param gqlClient - The GraphQL client instance used to execute the mutation.
+ * @param options - Configuration options for the client.
+ * @returns A function that accepts the arguments for creating an application and returns a promise resolving to the created application.
+ */
+export const applicationAccessTokenCreate = (gqlClient: GraphQLClient, options: ClientOptions) => {
+  return async (args: CreateApplicationAccessTokenArgs): Promise<string> => {
+    const { createApplicationAccessToken: applicationAccessToken } = await gqlClient.request(
+      createApplicationAccessToken,
+      args,
+    );
+    if (!applicationAccessToken.token) {
+      throw new Error("Failed to create application access token");
+    }
+    return applicationAccessToken.token;
+  };
+};

--- a/sdk/js/src/settlemint.ts
+++ b/sdk/js/src/settlemint.ts
@@ -2,6 +2,10 @@ import { ensureServer } from "@settlemint/sdk-utils/runtime";
 import { type Id, validate } from "@settlemint/sdk-utils/validation";
 import { GraphQLClient } from "graphql-request";
 import {
+  type CreateApplicationAccessTokenArgs,
+  applicationAccessTokenCreate,
+} from "./graphql/application-access-tokens.js";
+import {
   type Application,
   type CreateApplicationArgs,
   applicationCreate,
@@ -168,6 +172,9 @@ export interface SettlemintClient {
   foundry: {
     env: (blockchainNodeId: Id) => Promise<Record<string, string>>;
   };
+  applicationAccessToken: {
+    create: (args: CreateApplicationAccessTokenArgs) => Promise<string>;
+  };
 }
 
 /**
@@ -294,6 +301,9 @@ export function createSettleMintClient(options: ClientOptions): SettlemintClient
     },
     foundry: {
       env: getEnv(gqlClient, options),
+    },
+    applicationAccessToken: {
+      create: applicationAccessTokenCreate(gqlClient, options),
     },
   };
 }


### PR DESCRIPTION
## Summary by Sourcery

Add functionality to create a new application access token and refactor the Settlemint client to ensure separation by using two levels of clients.

New Features:
- Introduce a feature to create a new application access token through the Settlemint client.

Enhancements:
- Refactor the Settlemint client to use two levels of clients for better separation of concerns.