### PR TITLE
feat: allow pat tokens via env vars

### DIFF
--- a/sdk/cli/src/commands/connect/pat.prompt.ts
+++ b/sdk/cli/src/commands/connect/pat.prompt.ts
@@ -1,6 +1,6 @@
 import confirm from "@inquirer/confirm";
 import password from "@inquirer/password";
-import { PersonalAccessTokenSchema, validate } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, PersonalAccessTokenSchema, validate } from "@settlemint/sdk-utils/validation";
 import { getInstanceCredentials } from "../../utils/config";
 
 /**
@@ -12,17 +12,27 @@ import { getInstanceCredentials } from "../../utils/config";
  * @returns A promise that resolves to the validated access token.
  * @throws Will throw an error if the input validation fails.
  */
-export async function personalAccessTokenPrompt(instance: string): Promise<string> {
+export async function personalAccessTokenPrompt(
+  env: Partial<DotEnv>,
+  instance: string,
+  accept: boolean,
+): Promise<string> {
   const existingConfig = await getInstanceCredentials(instance);
+  const defaultPersonalAccessToken = env.SETTLEMINT_PERSONAL_ACCESS_TOKEN || existingConfig?.personalAccessToken;
+  const defaultPossible = accept && defaultPersonalAccessToken;
 
-  if (existingConfig) {
+  if (defaultPossible) {
+    return defaultPersonalAccessToken;
+  }
+
+  if (existingConfig && defaultPersonalAccessToken) {
     const useExisting = await confirm({
       message: `Do you want to use your existing personal access token for ${instance}?`,
       default: true,
     });
 
     if (useExisting) {
-      return existingConfig.personalAccessToken;
+      return defaultPersonalAccessToken;
     }
   }
 

--- a/sdk/cli/src/commands/login.ts
+++ b/sdk/cli/src/commands/login.ts
@@ -36,6 +36,7 @@ export function loginCommand(): Command {
       intro("Login to your SettleMint account");
 
       const env = await loadEnv(false, false);
+
       const instance = await instancePrompt(env, !!acceptDefaults);
 
       let personalAccessToken: string;
@@ -51,7 +52,7 @@ export function loginCommand(): Command {
           cancel("Invalid personal access token");
         }
       } else {
-        personalAccessToken = await personalAccessTokenPrompt(instance);
+        personalAccessToken = await personalAccessTokenPrompt(env, instance, !!acceptDefaults);
       }
 
       // Test the connection by trying to list workspaces

--- a/sdk/utils/src/validation/dot-env.schema.ts
+++ b/sdk/utils/src/validation/dot-env.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ApplicationAccessTokenSchema } from "./access-token.schema.js";
+import { ApplicationAccessTokenSchema, PersonalAccessTokenSchema } from "./access-token.schema.js";
 import { IdSchema } from "./id.schema.js";
 import { UrlSchema } from "./url.schema.js";
 /**
@@ -8,6 +8,7 @@ import { UrlSchema } from "./url.schema.js";
 export const DotEnvSchema = z.object({
   SETTLEMINT_INSTANCE: UrlSchema,
   SETTLEMINT_ACCESS_TOKEN: ApplicationAccessTokenSchema,
+  SETTLEMINT_PERSONAL_ACCESS_TOKEN: PersonalAccessTokenSchema.optional(),
   SETTLEMINT_WORKSPACE: IdSchema,
   SETTLEMINT_APPLICATION: IdSchema,
   SETTLEMINT_BLOCKCHAIN_NETWORK: IdSchema.optional(),


### PR DESCRIPTION
## Summary by Sourcery

Enable the use of personal access tokens through environment variables in the CLI, enhancing the personalAccessTokenPrompt function to support this feature.

New Features:
- Add support for using personal access tokens via environment variables in the CLI.

Enhancements:
- Modify the personalAccessTokenPrompt function to accept environment variables and default token usage.