### PR TITLE
fix: pipe input from child processes

### DIFF
--- a/sdk/utils/src/core/execute-command.ts
+++ b/sdk/utils/src/core/execute-command.ts
@@ -26,6 +26,7 @@ export async function executeCommand(
     child.on("error", (err) => reject(err));
     child.on("close", (code) => {
       if (code === 0 || code === null || code === 143) {
+        process.stdin.unpipe(child.stdin);
         resolve();
         return;
       }

--- a/test/create-smart-contract-set.e2e.test.ts
+++ b/test/create-smart-contract-set.e2e.test.ts
@@ -122,7 +122,6 @@ describe("Setup a smart contract set using the SDK", () => {
     // Confirm deployment
     deployCommand.stdin.write("y");
     deployCommand.stdin.end();
-
     const { output: deployOutput } = await deployCommand.result;
     expect(deployOutput).toInclude("successfully deployed 🚀");
 
@@ -133,12 +132,9 @@ describe("Setup a smart contract set using the SDK", () => {
         cwd: projectDir,
       },
     );
-    // Confirm deployment
+    // Confirm deployment and reset
     resetCommand.stdin.write("y");
     resetCommand.stdin.end();
-    // Confirm reset
-    deployCommand.stdin.write("y");
-    deployCommand.stdin.end();
     const { output: outputReset } = await resetCommand.result;
     expect(outputReset).toInclude("successfully deployed 🚀");
   });

--- a/test/utils/run-command.ts
+++ b/test/utils/run-command.ts
@@ -12,6 +12,7 @@ const DEFAULT_ENV: Record<string, string> = {
   SETTLEMINT_INSTANCE: process.env.SETTLEMINT_INSTANCE!,
   CI: isInCi ? "true" : "false",
   NODE_ENV: "development",
+  HARDHAT_IGNITION_CONFIRM_RESET: "false",
 };
 
 if (isLocalEnv()) {


### PR DESCRIPTION
## Summary by Sourcery

Fix the handling of stdin input from child processes to ensure proper command execution and update tests to confirm deployments and resets by writing to stdin.

Bug Fixes:
- Fix the issue of not piping input from child processes by ensuring that stdin is correctly handled.

Tests:
- Update tests to handle stdin input for deployment and reset commands, confirming actions by writing to stdin.