### PR TITLE
feat: add command to create minio storage

### DIFF
--- a/sdk/cli/src/commands/connect.ts
+++ b/sdk/cli/src/commands/connect.ts
@@ -7,6 +7,7 @@ import {
   getGraphEndpoint,
   getHasuraEndpoints,
   getIpfsEndpoints,
+  getMinioEndpoints,
   getPortalEndpoints,
 } from "@/utils/get-cluster-service-endpoint";
 import { Command } from "@commander-js/extra-typings";
@@ -99,11 +100,7 @@ export function connectCommand(): Command {
           ...getPortalEndpoints(portal),
           SETTLEMINT_HD_PRIVATE_KEY: hdPrivateKey?.uniqueName,
           SETTLEMINT_MINIO: minio?.id,
-          SETTLEMINT_MINIO_ENDPOINT: minio?.endpoints.find((endpoint) => endpoint.id.includes("s3-api"))?.displayValue,
-          SETTLEMINT_MINIO_ACCESS_KEY: minio?.credentials.find((credential) => credential.id.includes("access-key"))
-            ?.displayValue,
-          SETTLEMINT_MINIO_SECRET_KEY: minio?.credentials.find((credential) => credential.id.includes("secret-key"))
-            ?.displayValue,
+          ...getMinioEndpoints(minio),
           SETTLEMINT_IPFS: ipfs?.id,
           ...getIpfsEndpoints(ipfs),
           SETTLEMINT_CUSTOM_DEPLOYMENT: cDeployment?.id,

--- a/sdk/cli/src/commands/platform/storage/create.ts
+++ b/sdk/cli/src/commands/platform/storage/create.ts
@@ -1,5 +1,6 @@
 import { Command } from "@commander-js/extra-typings";
 import { ipfsStorageCreateCommand } from "./ipfs/create";
+import { minioStorageCreateCommand } from "./minio/create";
 
 /**
  * Creates and returns the 'storage' command for the SettleMint SDK.
@@ -11,5 +12,6 @@ export function storageCreateCommand(): Command {
   return new Command("storage")
     .alias("st")
     .description("Create a storage service in the SettleMint platform")
-    .addCommand(ipfsStorageCreateCommand());
+    .addCommand(ipfsStorageCreateCommand())
+    .addCommand(minioStorageCreateCommand());
 }

--- a/sdk/cli/src/commands/platform/storage/minio/create.test.ts
+++ b/sdk/cli/src/commands/platform/storage/minio/create.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { Command } from "@commander-js/extra-typings";
+import { minioStorageCreateCommand } from "./create.js";
+
+describe("minioStorageCreateCommand", () => {
+  test("executes command with required arguments", () => {
+    let commandOptions: Record<string, unknown> = {};
+    let commandArgs = "";
+    const program = new Command();
+    program.addCommand(
+      minioStorageCreateCommand()
+        .exitOverride()
+        .action((args: string, options: Record<string, unknown>) => {
+          commandArgs = args;
+          commandOptions = options;
+        }),
+    );
+    program.parse(["node", "test", "minio", "test-storage", "--provider", "gke", "--region", "europe"]);
+
+    expect(commandArgs).toBe("test-storage");
+    expect(commandOptions).toEqual({
+      provider: "gke",
+      region: "europe",
+      size: "SMALL",
+      type: "SHARED",
+    });
+  });
+
+  test("executes command with optional parameters", () => {
+    let commandOptions: Record<string, unknown> = {};
+    let commandArgs = "";
+    const program = new Command();
+    program.addCommand(
+      minioStorageCreateCommand()
+        .exitOverride()
+        .action((args: string, options: Record<string, unknown>) => {
+          commandArgs = args;
+          commandOptions = options;
+        }),
+    );
+    program.parse([
+      "node",
+      "test",
+      "minio",
+      "test-storage",
+      "--provider",
+      "gke",
+      "--region",
+      "europe",
+      "--application-id",
+      "123456789",
+      "--size",
+      "MEDIUM",
+      "--type",
+      "DEDICATED",
+    ]);
+
+    expect(commandArgs).toBe("test-storage");
+    expect(commandOptions).toEqual({
+      provider: "gke",
+      region: "europe",
+      applicationId: "123456789",
+      size: "MEDIUM",
+      type: "DEDICATED",
+    });
+  });
+});

--- a/sdk/cli/src/commands/platform/storage/minio/create.ts
+++ b/sdk/cli/src/commands/platform/storage/minio/create.ts
@@ -1,0 +1,55 @@
+import { addClusterServiceArgs } from "@/commands/platform/common/cluster-service.args";
+import { getMinioEndpoints } from "@/utils/get-cluster-service-endpoint";
+import type { DotEnv } from "@settlemint/sdk-utils";
+import { getCreateCommand } from "../../common/create-command";
+
+/**
+ * Creates and returns the 'minio' storage command for the SettleMint SDK.
+ * This command creates a new MinIO storage in the SettleMint platform.
+ * It requires an application ID.
+ */
+export function minioStorageCreateCommand() {
+  return getCreateCommand({
+    name: "minio",
+    type: "storage",
+    alias: "m",
+    execute: (cmd, baseAction) => {
+      addClusterServiceArgs(cmd)
+        .option("--application-id <applicationId>", "Application ID")
+        .action(async (name, { applicationId, provider, region, size, type, ...defaultArgs }) => {
+          return baseAction(defaultArgs, async (settlemint, env) => {
+            const application = applicationId ?? env.SETTLEMINT_APPLICATION!;
+            const result = await settlemint.storage.create({
+              name,
+              applicationId: application,
+              storageProtocol: "MINIO",
+              provider,
+              region,
+              size,
+              type,
+            });
+            return {
+              result,
+              mapDefaultEnv: (): Partial<DotEnv> => {
+                return {
+                  SETTLEMINT_APPLICATION: application,
+                  SETTLEMINT_MINIO: result.id,
+                  ...getMinioEndpoints(result),
+                };
+              },
+            };
+          });
+        });
+    },
+    examples: [
+      {
+        description: "Create a MinIO storage and save as default",
+        command: "platform create storage minio my-storage --accept-defaults -d",
+      },
+      {
+        description: "Create a MinIO storage in a different application",
+        command: "platform create storage minio my-storage --application-id app-123",
+      },
+    ],
+  });
+}

--- a/sdk/cli/src/commands/platform/storage/minio/restart.ts
+++ b/sdk/cli/src/commands/platform/storage/minio/restart.ts
@@ -1,0 +1,17 @@
+import { getRestartCommand } from "@/commands/platform/common/restart-command";
+
+/**
+ * Creates and returns the 'minio restart' command for the SettleMint SDK.
+ * This command restarts a MinIO storage service in the SettleMint platform.
+ */
+export function minioRestartCommand() {
+  return getRestartCommand({
+    name: "minio",
+    type: "storage",
+    alias: "m",
+    envKey: "SETTLEMINT_MINIO",
+    restartFunction: async (settlemint, id) => {
+      return settlemint.storage.restart(id);
+    },
+  });
+}

--- a/sdk/cli/src/commands/platform/storage/restart.ts
+++ b/sdk/cli/src/commands/platform/storage/restart.ts
@@ -1,5 +1,6 @@
 import { Command } from "@commander-js/extra-typings";
 import { ipfsRestartCommand } from "./ipfs/restart";
+import { minioRestartCommand } from "./minio/restart";
 
 /**
  * Creates and returns the 'storage' command for the SettleMint SDK.
@@ -11,5 +12,6 @@ export function storageRestartCommand(): Command {
   return new Command("storage")
     .alias("st")
     .description("Restart a storage service in the SettleMint platform")
-    .addCommand(ipfsRestartCommand());
+    .addCommand(ipfsRestartCommand())
+    .addCommand(minioRestartCommand());
 }

--- a/sdk/cli/src/utils/get-cluster-service-endpoint.ts
+++ b/sdk/cli/src/utils/get-cluster-service-endpoint.ts
@@ -92,3 +92,17 @@ export function getBlockscoutEndpoints(service: Insights | undefined): Partial<D
     SETTLEMINT_BLOCKSCOUT_UI_ENDPOINT: uiEndpoint,
   };
 }
+
+export function getMinioEndpoints(service: Storage | undefined): Partial<DotEnv> {
+  if (!service || service.__typename !== "MinioStorage") {
+    return {};
+  }
+
+  return {
+    SETTLEMINT_MINIO_ENDPOINT: service?.endpoints.find((endpoint) => endpoint.id.includes("s3-api"))?.displayValue,
+    SETTLEMINT_MINIO_ACCESS_KEY: service?.credentials.find((credential) => credential.id.includes("access-key"))
+      ?.displayValue,
+    SETTLEMINT_MINIO_SECRET_KEY: service?.credentials.find((credential) => credential.id.includes("secret-key"))
+      ?.displayValue,
+  };
+}

--- a/test/constants/test-resources.ts
+++ b/test/constants/test-resources.ts
@@ -6,6 +6,7 @@ export const NETWORK_NAME = "Starter Kit Network";
 export const NODE_NAME = "Starter Kit Node";
 export const PRIVATE_KEY_NAME = "Starter Kit Private Key";
 export const PRIVATE_KEY_SMART_CONTRACTS_NAME = "Starter Kit Private Key Smart Contracts";
+export const MINIO_NAME = "Starter Kit MinIO";
 export const IPFS_NAME = "Starter Kit IPFS";
 export const GRAPH_NAME = "Starter Kit Graph";
 export const PORTAL_NAME = "Starter Kit Portal";

--- a/test/create-new-project.e2e.test.ts
+++ b/test/create-new-project.e2e.test.ts
@@ -99,7 +99,10 @@ describe("Setup a project using the SDK", () => {
   test("Install dependencies and link SDK to use local one", async () => {
     const env = { NODE_ENV: "production" };
     await $`bun link`.cwd("./sdk/cli");
-    await $`bun install`.cwd(projectDir).env(env);
+    await $`bun install`.cwd(projectDir).env({
+      ...process.env,
+      ...env,
+    });
     await $`bun link @settlemint/sdk-cli`.cwd(projectDir);
   });
 
@@ -203,6 +206,7 @@ describe("Setup a project using the SDK", () => {
     }).result;
 
     expect(output).toInclude("Generating Hasura resources");
+    expect(output).toInclude("Generating Minio resources");
     expect(output).toInclude("Generating IPFS resources");
     expect(output).toInclude("Generating Blockscout resources");
     expect(output).toInclude("Generating Portal resources");


### PR DESCRIPTION
## Summary by Sourcery

Add support for creating MinIO storage.

New Features:
- Introduce a new command to create MinIO storage, enabling users to easily set up and manage MinIO storage within their projects.

Tests:
- Include tests to verify the functionality of the new MinIO storage creation command.