### PR TITLE
fix: client side usage

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-the-graph.ts
+++ b/sdk/cli/src/commands/codegen/codegen-the-graph.ts
@@ -58,7 +58,7 @@ export const { client: theGraphClient${nameSuffix}, graphql: theGraphGraphql${na
     Timestamp: string;
   };
   }>({
-  instances: JSON.parse(process.env.SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS!),
+  instances: JSON.parse(process.env.SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS || '[]'),
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!, // undefined in browser, by design to not leak the secrets
   subgraphName: "${name}",
 });`,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the client would crash if the `SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS` environment variable was not set.