### PR TITLE
fix: ipfs, minio instance endpoints in codegen

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-ipfs.ts
+++ b/sdk/cli/src/commands/codegen/codegen-ipfs.ts
@@ -14,7 +14,7 @@ export async function codegenIpfs(env: DotEnv) {
   const clientTemplate = `import { createServerIpfsClient } from "@settlemint/sdk-ipfs";
 
 export const { client } = createServerIpfsClient({
-  instance: process.env.SETTLEMINT_HASURA_ENDPOINT!,
+  instance: process.env.SETTLEMINT_IPFS_API_ENDPOINT!,
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
 });`;
 

--- a/sdk/cli/src/commands/codegen/codegen-minio.ts
+++ b/sdk/cli/src/commands/codegen/codegen-minio.ts
@@ -14,7 +14,7 @@ export async function codegenMinio(env: DotEnv) {
   const clientTemplate = `import { createServerMinioClient } from "@settlemint/sdk-minio";
 
 export const { client } = createServerMinioClient({
-  instance: process.env.SETTLEMINT_HASURA_ENDPOINT!,
+  instance: process.env.SETTLEMINT_MINIO_ENDPOINT!,
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
   accessKey: process.env.SETTLEMINT_MINIO_ACCESS_KEY!,
   secretKey: process.env.SETTLEMINT_MINIO_SECRET_KEY!


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed incorrect environment variables being used for IPFS and Minio client generation.