### PR TITLE
fix: allow fallback to pat token for subgraph cmds

### DIFF
--- a/sdk/cli/src/commands/platform/common/create-command.ts
+++ b/sdk/cli/src/commands/platform/common/create-command.ts
@@ -82,7 +82,6 @@ export function getCreateCommand({
       env,
       instance,
       prefer: usePersonalAccessToken ? "personal" : "application",
-      allowFallback: false,
     });
 
     const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/common/delete-command.ts
+++ b/sdk/cli/src/commands/platform/common/delete-command.ts
@@ -85,7 +85,6 @@ ${createExamples([
         env,
         instance,
         prefer: usePersonalAccessToken ? "personal" : "application",
-        allowFallback: false,
       });
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/common/restart-command.ts
+++ b/sdk/cli/src/commands/platform/common/restart-command.ts
@@ -75,7 +75,6 @@ ${createExamples([
         env,
         instance,
         prefer: usePersonalAccessToken ? "personal" : "application",
-        allowFallback: false,
       });
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/platform/custom-deployments/update.ts
+++ b/sdk/cli/src/commands/platform/custom-deployments/update.ts
@@ -44,7 +44,6 @@ export function customDeploymentsUpdateCommand(): Command<[tag: string], { prod?
         env,
         instance,
         prefer: "application",
-        allowFallback: false,
       });
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
@@ -50,7 +50,6 @@ export function hardhatDeployRemoteCommand() {
         env,
         instance,
         prefer: "application",
-        allowFallback: true,
       });
 
       const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
@@ -28,7 +28,6 @@ export function hardhatScriptRemoteCommand() {
       env,
       instance,
       prefer: "application",
-      allowFallback: true,
     });
 
     const settlemint = createSettleMintClient({

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/build.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/build.ts
@@ -21,7 +21,6 @@ export function subgraphBuildCommand() {
         env,
         instance,
         prefer: "application",
-        allowFallback: true,
       });
 
       await subgraphSetup({

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/codegen.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/codegen.ts
@@ -21,7 +21,6 @@ export function subgraphCodegenCommand() {
         env,
         instance,
         prefer: "application",
-        allowFallback: true,
       });
 
       await subgraphSetup({

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
@@ -32,7 +32,6 @@ export function subgraphDeployCommand() {
         env,
         instance,
         prefer: "application",
-        allowFallback: true,
       });
 
       const theGraphMiddleware = await subgraphSetup({

--- a/sdk/cli/src/utils/get-app-or-personal-token.test.ts
+++ b/sdk/cli/src/utils/get-app-or-personal-token.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
-import { missingAccessTokenError, missingPersonalAccessTokenError } from "@/error/missing-config-error";
+import { missingPersonalAccessTokenError } from "@/error/missing-config-error";
 import { getApplicationOrPersonalAccessToken } from "./get-app-or-personal-token";
 
 const mockConfig = (mockReturn: unknown) => {
@@ -29,13 +29,12 @@ describe("getApplicationOrPersonalAccessToken", () => {
       },
       instance: "test-instance",
       prefer: "application",
-      allowFallback: false,
     });
 
     expect(result).toBe(appToken);
   });
 
-  it("Preference - Application access token - Fallback allowed - Fallback to personal access token if no application access token", async () => {
+  it("Preference - Application access token - Fallback to personal access token if no application access token", async () => {
     mockConfig({
       getInstanceCredentials: mock(() => ({
         personalAccessToken: personalToken,
@@ -46,39 +45,9 @@ describe("getApplicationOrPersonalAccessToken", () => {
       env: {},
       instance: "test-instance",
       prefer: "application",
-      allowFallback: true,
     });
 
     expect(result).toBe(personalToken);
-  });
-
-  it("Preference - Application access token - Fallback disallowed - Error if no application access token", async () => {
-    mockConfig({
-      getInstanceCredentials: mock(() => ({
-        personalAccessToken: personalToken,
-      })),
-    });
-
-    const result = await getApplicationOrPersonalAccessToken({
-      env: {},
-      instance: "test-instance",
-      prefer: "application",
-      allowFallback: false,
-    });
-    expect(result).toBe(missingAccessTokenError(true));
-
-    mockConfig({
-      getInstanceCredentials: mock(() => ({
-        personalAccessToken: undefined,
-      })),
-    });
-    const result2 = await getApplicationOrPersonalAccessToken({
-      env: {},
-      instance: "test-instance",
-      prefer: "application",
-      allowFallback: false,
-    });
-    expect(result2).toBe(missingAccessTokenError(false));
   });
 
   it("Preference - Personal access token - Returns personal access token when set", async () => {
@@ -94,13 +63,12 @@ describe("getApplicationOrPersonalAccessToken", () => {
       },
       instance: "test-instance",
       prefer: "personal",
-      allowFallback: false,
     });
 
     expect(result).toBe(personalToken);
   });
 
-  it("Preference - Personal access token - Fallback allowed - Fallback to application access token if no personal access token", async () => {
+  it("Preference - Personal access token -  Error if no personal access token", async () => {
     mockConfig({
       getInstanceCredentials: mock(() => ({
         personalAccessToken: undefined,
@@ -113,26 +81,6 @@ describe("getApplicationOrPersonalAccessToken", () => {
       },
       instance: "test-instance",
       prefer: "personal",
-      allowFallback: true,
-    });
-
-    expect(result).toBe(appToken);
-  });
-
-  it("Preference - Personal access token - Fallback disallowed - Error if no personal access token", async () => {
-    mockConfig({
-      getInstanceCredentials: mock(() => ({
-        personalAccessToken: undefined,
-      })),
-    });
-
-    const result = await getApplicationOrPersonalAccessToken({
-      env: {
-        SETTLEMINT_ACCESS_TOKEN: appToken,
-      },
-      instance: "test-instance",
-      prefer: "personal",
-      allowFallback: false,
     });
 
     expect(result).toBe(missingPersonalAccessTokenError());

--- a/sdk/cli/src/utils/get-app-or-personal-token.ts
+++ b/sdk/cli/src/utils/get-app-or-personal-token.ts
@@ -6,17 +6,16 @@ export const getApplicationOrPersonalAccessToken = async ({
   env,
   instance,
   prefer,
-  allowFallback,
 }: {
   env: Partial<DotEnv>;
   instance: string;
   prefer: "application" | "personal";
-  allowFallback: boolean;
 }) => {
   const applicationAccessToken = env.SETTLEMINT_ACCESS_TOKEN;
   const personalAccessToken = (await getInstanceCredentials(instance))?.personalAccessToken;
   const preferredToken = prefer === "application" ? applicationAccessToken : personalAccessToken;
   const fallbackToken = prefer === "application" ? personalAccessToken : applicationAccessToken;
+  const allowFallback = prefer === "application";
 
   if (preferredToken) {
     return preferredToken;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed an issue where subgraph commands would fail if the application token was not available.