### PR TITLE
fix: login dx improvements

### DIFF
--- a/sdk/cli/src/commands/login.ts
+++ b/sdk/cli/src/commands/login.ts
@@ -33,46 +33,56 @@ export function loginCommand(): Command {
     .option("-a, --accept-defaults", "Accept the default and previously set values")
     .option("-d, --default", "Set this instance as the default")
     .option("--token-stdin", "Provide a token using STDIN")
-    .action(async ({ acceptDefaults, default: isDefault, tokenStdin }) => {
+    .option("-i, --instance <instance>", "The instance to login to (defaults to the instance in the .env file)")
+    .action(async ({ acceptDefaults, default: isDefault, tokenStdin, instance }, cmd) => {
       intro("Login to your SettleMint account");
 
+      const autoAccept = !!acceptDefaults || !!tokenStdin;
+
       const env = await loadEnv(false, false);
+      const selectedInstance = instance ?? (await instancePrompt(env, autoAccept));
 
-      const instance = await instancePrompt(env, !!acceptDefaults);
-
-      let personalAccessToken: string;
+      let personalAccessToken = "";
       if (tokenStdin) {
-        const chunks: Buffer[] = [];
-        for await (const chunk of process.stdin) {
-          chunks.push(Buffer.from(chunk));
+        if (cmd.args.length > 0) {
+          cancel("A token should be provided using STDIN, not as an argument");
         }
-        personalAccessToken = Buffer.concat(chunks).toString().trim();
+        personalAccessToken = await Promise.race([
+          (async () => {
+            const chunks: Buffer[] = [];
+            for await (const chunk of process.stdin) {
+              chunks.push(Buffer.from(chunk));
+            }
+            return Buffer.concat(chunks).toString().trim();
+          })(),
+          new Promise<string>((resolve) => setTimeout(() => resolve(""), 1_000)),
+        ]);
         try {
           validate(PersonalAccessTokenSchema, personalAccessToken);
         } catch {
           cancel("Invalid personal access token");
         }
       } else {
-        personalAccessToken = await personalAccessTokenPrompt(env, instance, !!acceptDefaults);
+        personalAccessToken = await personalAccessTokenPrompt(env, selectedInstance, autoAccept);
       }
 
       // Test the connection by trying to list workspaces
       const client = createSettleMintClient({
-        instance,
+        instance: selectedInstance,
         accessToken: personalAccessToken,
       });
 
       try {
         await loginSpinner(client);
       } catch (error) {
-        cancel(`Invalid personal access token for instance ${instance}`);
+        cancel(`Invalid personal access token for instance ${selectedInstance}`);
       }
 
       // If we get here, the connection was successful
-      await storeCredentials(personalAccessToken, instance);
+      await storeCredentials(personalAccessToken, selectedInstance);
 
       if (isDefault) {
-        await setDefaultInstance(instance);
+        await setDefaultInstance(selectedInstance);
       }
 
       outro("Successfully logged in to SettleMint!");

--- a/test/login.e2e.test.ts
+++ b/test/login.e2e.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { forceExitAllCommands, runCommand } from "./utils/run-command";
+
+const COMMAND_TEST_SCOPE = "login-test";
+
+afterEach(() => {
+  forceExitAllCommands(COMMAND_TEST_SCOPE);
+});
+
+describe("Login command", () => {
+  test("Regular login should succeed", async () => {
+    const command = runCommand(COMMAND_TEST_SCOPE, ["login"]);
+    const onOutput = (message: string) => {
+      if (message.includes("What is the URL of your SettleMint instance?")) {
+        command.stdin.cork();
+        command.stdin.write(`${process.env.SETTLEMINT_INSTANCE}\n`);
+        command.stdin.uncork();
+      }
+      if (message.includes("Do you want to use your existing personal access token")) {
+        command.stdin.cork();
+        command.stdin.write("y\n");
+        command.stdin.uncork();
+      }
+    };
+    command.stdout.on("data", onOutput);
+    const { output } = await command.result;
+    command.stdout.off("data", onOutput);
+    expect(output).toInclude("Successfully logged in to SettleMint!");
+  });
+
+  test("Login with valid token via stdin should succeed", async () => {
+    const command = runCommand(COMMAND_TEST_SCOPE, [
+      "login",
+      "--token-stdin",
+      "--instance",
+      process.env.SETTLEMINT_INSTANCE!,
+    ]);
+    command.stdin.write(`${process.env.SETTLEMINT_ACCESS_TOKEN_E2E_TESTS}\n`);
+    command.stdin.end();
+
+    const { output } = await command.result;
+    expect(output).toInclude("Successfully logged in to SettleMint!");
+  });
+
+  test("Login with no token via stdin should fail", async () => {
+    const command = runCommand(COMMAND_TEST_SCOPE, ["login", "--token-stdin"]);
+    expect(() => command.result).toThrow();
+  });
+
+  test("Login with invalid token via stdin should fail", async () => {
+    const command = runCommand(COMMAND_TEST_SCOPE, ["login", "--token-stdin"]);
+    command.stdin.write("invalid_token\n");
+    command.stdin.end();
+    const outputs: string[] = [];
+    command.stdout.on("data", (data: Buffer) => {
+      outputs.push(data.toString());
+    });
+    expect(() => command.result).toThrow();
+    expect(outputs.join("\n")).toInclude("Invalid personal access token");
+  });
+
+  test("Login with token as argument should fail", async () => {
+    const command = runCommand(COMMAND_TEST_SCOPE, [
+      "login",
+      "--token-stdin",
+      process.env.SETTLEMINT_ACCESS_TOKEN_E2E_TESTS ?? "some_token",
+    ]);
+    const outputs: string[] = [];
+    command.stdout.on("data", (data: Buffer) => {
+      outputs.push(data.toString());
+    });
+    expect(() => command.result).toThrow();
+    expect(outputs.join("\n")).toInclude("A token should be provided using STDIN, not as an argument");
+  });
+});


### PR DESCRIPTION
## Summary by Sourcery

Add an option to specify the instance URL when logging in using the CLI.

New Features:
- Allow users to specify the instance URL for login via the `--instance` flag.

Tests:
- Add end-to-end tests for the login command.