### PR TITLE
fix: do not prompt for aat token when running in CI

### DIFF
--- a/sdk/cli/src/commands/connect/aat.prompt.ts
+++ b/sdk/cli/src/commands/connect/aat.prompt.ts
@@ -29,9 +29,9 @@ export async function applicationAccessTokenPrompt(
   accept: boolean,
 ): Promise<string | undefined> {
   const defaultAccessToken = env.SETTLEMINT_ACCESS_TOKEN;
-  const defaultPossible = (accept || isInCi) && defaultAccessToken;
+  const defaultPossible = accept && defaultAccessToken;
 
-  if (defaultPossible) {
+  if (defaultPossible || isInCi) {
     return defaultAccessToken;
   }
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Skip prompting for application access token if running in CI.