### PR TITLE
fix: add e2e-sdk slack report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,7 +128,7 @@ jobs:
           E2E_GITHUB_TOKEN: ${{ env.E2E_GITHUB_TOKEN }}
 
       - name: Send Slack notification
-        if: !cancelled()
+        if: ${{ !cancelled() }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Send Slack notification on completion of the E2E tests.