### PR TITLE
fix: update of docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5
         with:
-          commit_message: "chore: update docs"
+          commit_message: "chore: update docs [skip ci]"
           branch: main
           file_pattern: 'sdk/cli/docs/settlemint.md sdk/cli/docs/**/*.md sdk/**/README.md'
 

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -1,5 +1,6 @@
 import packageJson from "./package.json" with { type: "json" };
 
+
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 export default {
   // Output configuration
@@ -8,7 +9,7 @@ export default {
   entryFileName: "REFERENCE.md",
   readme: "none",
   exclude: ["**/node_modules/**"],
-  gitRevision: `v${packageJson.version}`,
+  gitRevision: `v${packageJson.version.replace(/-\w+$/, "")}`,
   mergeModulesMergeMode: "project",
 
   // Content organization


### PR DESCRIPTION
## Summary by Sourcery

Update documentation generation to use the release version instead of pre-release identifiers. Update the auto-commit action message to skip CI.

Documentation:
- Generate documentation using the release version.

Tests:
- Update auto-commit action message to skip CI.