### PR TITLE
fix: better explain format of the different tokens

### DIFF
--- a/sdk/cli/src/commands/connect/aat.prompt.ts
+++ b/sdk/cli/src/commands/connect/aat.prompt.ts
@@ -127,7 +127,7 @@ export async function applicationAccessTokenPrompt(
         validate(ApplicationAccessTokenSchema, value);
         return true;
       } catch (error) {
-        return "Invalid application access token";
+        return "Invalid application access token, it should start with sm_aat_...";
       }
     },
   });

--- a/sdk/cli/src/commands/connect/aat.prompt.ts
+++ b/sdk/cli/src/commands/connect/aat.prompt.ts
@@ -121,7 +121,7 @@ export async function applicationAccessTokenPrompt(
   }
 
   return password({
-    message: "What is the application access token for your application in SettleMint?",
+    message: "What is the application access token for your application in SettleMint? (format: sm_aat_...)",
     validate(value) {
       try {
         validate(ApplicationAccessTokenSchema, value);

--- a/sdk/cli/src/commands/connect/pat.prompt.ts
+++ b/sdk/cli/src/commands/connect/pat.prompt.ts
@@ -37,7 +37,7 @@ export async function personalAccessTokenPrompt(
   }
 
   return password({
-    message: "What is your personal access token in SettleMint?",
+    message: "What is your personal access token in SettleMint? (format: sm_pat_...)",
     validate(value) {
       try {
         validate(PersonalAccessTokenSchema, value);

--- a/sdk/cli/src/commands/connect/pat.prompt.ts
+++ b/sdk/cli/src/commands/connect/pat.prompt.ts
@@ -43,7 +43,7 @@ export async function personalAccessTokenPrompt(
         validate(PersonalAccessTokenSchema, value);
         return true;
       } catch (error) {
-        return "Invalid personal access token";
+        return "Invalid personal access token, it should start with sm_pat_...";
       }
     },
   });


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Improve the clarity of the prompts for application and personal access tokens by specifying the expected format (e.g., "sm_aat_...").