### PR TITLE
fix: streamline private key creation commands for ECDSA and HSM types

### DIFF
--- a/sdk/cli/src/commands/platform/common/create-command.ts
+++ b/sdk/cli/src/commands/platform/common/create-command.ts
@@ -107,7 +107,7 @@ export function getCreateCommand({
       });
       const platformConfig = await settlemint.platform.config();
 
-      if (requiresDeployment) {
+      if (cmd.options.some((option) => option.long === "--provider")) {
         const selectedProvider = await providerPrompt(platformConfig, provider);
         if (!selectedProvider) {
           return nothingSelectedError("provider");

--- a/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.test.ts
+++ b/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.test.ts
@@ -15,26 +15,12 @@ describe("privateKeyHdCreateCommand", () => {
           commandOptions = options;
         }),
     );
-    program.parse([
-      "node",
-      "test",
-      "accessible-ecdsa-p256",
-      "test-key",
-      "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
-    ]);
+    program.parse(["node", "test", "accessible-ecdsa-p256", "test-key", "--accept-defaults"]);
 
     // Validate command was executed with correct arguments
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 
@@ -56,10 +42,6 @@ describe("privateKeyHdCreateCommand", () => {
       "accessible-ecdsa-p256",
       "test-key",
       "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
       "--application",
       "my-app",
       "--blockchain-node",
@@ -69,12 +51,8 @@ describe("privateKeyHdCreateCommand", () => {
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
       application: "my-app",
       blockchainNode: "node-1",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 });

--- a/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.ts
@@ -1,5 +1,4 @@
 import { blockchainNodePrompt } from "@/commands/connect/blockchain-node.prompt";
-import { addClusterServiceArgs } from "@/commands/platform/common/cluster-service.args";
 import { missingApplication } from "@/error/missing-config-error";
 import { nothingSelectedError } from "@/error/nothing-selected-error";
 import { getCreateCommand } from "../../common/create-command";
@@ -16,57 +15,50 @@ export function privateKeyAccessibleCreateCommand() {
     subType: "ACCESSIBLE-ECDSA-P256",
     alias: "acc",
     execute: (cmd, baseAction) => {
-      addClusterServiceArgs(cmd)
+      cmd
         .option("--application <application>", "Application unique name")
         .option("--blockchain-node <blockchainNode>", "Blockchain Node unique name")
-        .action(
-          async (
-            name,
-            { application, blockchainNode, provider, region, size, type, acceptDefaults, ...defaultArgs },
-          ) => {
-            return baseAction(
-              {
-                ...defaultArgs,
-                acceptDefaults,
-                provider,
-                region,
-              },
-              async (settlemint, env) => {
-                const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
-                if (!applicationUniqueName) {
-                  return missingApplication();
-                }
-                let blockchainNodeUniqueName = blockchainNode;
-                if (!blockchainNodeUniqueName) {
-                  const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
-                  const node = await blockchainNodePrompt({
-                    env,
-                    nodes: blockchainNodes,
-                    accept: acceptDefaults,
-                    isRequired: true,
-                  });
-                  if (!node) {
-                    return nothingSelectedError("blockchain node");
-                  }
-                  blockchainNodeUniqueName = node.uniqueName;
-                }
-                const result = await settlemint.privateKey.create({
-                  name,
-                  applicationUniqueName,
-                  privateKeyType: "ACCESSIBLE_ECDSA_P256",
-                  blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
-                  provider,
-                  region,
-                  size,
-                  type,
+        .action(async (name, { application, blockchainNode, acceptDefaults, ...defaultArgs }) => {
+          return baseAction(
+            {
+              ...defaultArgs,
+              acceptDefaults,
+            },
+            async (settlemint, env) => {
+              const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
+              if (!applicationUniqueName) {
+                return missingApplication();
+              }
+              let blockchainNodeUniqueName = blockchainNode;
+              if (!blockchainNodeUniqueName) {
+                const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
+                const node = await blockchainNodePrompt({
+                  env,
+                  nodes: blockchainNodes,
+                  accept: acceptDefaults,
+                  isRequired: true,
                 });
-                return {
-                  result,
-                };
-              },
-            );
-          },
-        );
+                if (!node) {
+                  return nothingSelectedError("blockchain node");
+                }
+                blockchainNodeUniqueName = node.uniqueName;
+              }
+              const result = await settlemint.privateKey.create({
+                name,
+                applicationUniqueName,
+                privateKeyType: "ACCESSIBLE_ECDSA_P256",
+                blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
+                provider: "GKE",
+                region: "EUROPE",
+                size: "SMALL",
+                type: "SHARED",
+              });
+              return {
+                result,
+              };
+            },
+          );
+        });
     },
     examples: [
       {

--- a/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.test.ts
+++ b/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.test.ts
@@ -15,26 +15,12 @@ describe("privateKeyHdCreateCommand", () => {
           commandOptions = options;
         }),
     );
-    program.parse([
-      "node",
-      "test",
-      "hd-ecdsa-p256",
-      "test-key",
-      "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
-    ]);
+    program.parse(["node", "test", "hd-ecdsa-p256", "test-key", "--accept-defaults"]);
 
     // Validate command was executed with correct arguments
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 
@@ -56,10 +42,6 @@ describe("privateKeyHdCreateCommand", () => {
       "hd-ecdsa-p256",
       "test-key",
       "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
       "--application",
       "my-app",
       "--blockchain-node",
@@ -69,12 +51,8 @@ describe("privateKeyHdCreateCommand", () => {
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
       application: "my-app",
       blockchainNode: "node-1",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 });

--- a/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.ts
@@ -1,5 +1,4 @@
 import { blockchainNodePrompt } from "@/commands/connect/blockchain-node.prompt";
-import { addClusterServiceArgs } from "@/commands/platform/common/cluster-service.args";
 import { missingApplication } from "@/error/missing-config-error";
 import { nothingSelectedError } from "@/error/nothing-selected-error";
 import type { DotEnv } from "@settlemint/sdk-utils";
@@ -17,63 +16,56 @@ export function privateKeyHdCreateCommand() {
     subType: "HD-ECDSA-P256",
     alias: "hd",
     execute: (cmd, baseAction) => {
-      addClusterServiceArgs(cmd)
+      cmd
         .option("--application <application>", "Application unique name")
         .option("--blockchain-node <blockchainNode>", "Blockchain Node unique name")
-        .action(
-          async (
-            name,
-            { application, blockchainNode, provider, region, size, type, acceptDefaults, ...defaultArgs },
-          ) => {
-            return baseAction(
-              {
-                ...defaultArgs,
-                acceptDefaults,
-                provider,
-                region,
-              },
-              async (settlemint, env) => {
-                const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
-                if (!applicationUniqueName) {
-                  return missingApplication();
-                }
-                let blockchainNodeUniqueName = blockchainNode;
-                if (!blockchainNodeUniqueName) {
-                  const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
-                  const node = await blockchainNodePrompt({
-                    env,
-                    nodes: blockchainNodes,
-                    accept: acceptDefaults,
-                    isRequired: true,
-                  });
-                  if (!node) {
-                    return nothingSelectedError("blockchain node");
-                  }
-                  blockchainNodeUniqueName = node.uniqueName;
-                }
-                const result = await settlemint.privateKey.create({
-                  name,
-                  applicationUniqueName,
-                  privateKeyType: "HD_ECDSA_P256",
-                  blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
-                  provider,
-                  region,
-                  size,
-                  type,
+        .action(async (name, { application, blockchainNode, acceptDefaults, ...defaultArgs }) => {
+          return baseAction(
+            {
+              ...defaultArgs,
+              acceptDefaults,
+            },
+            async (settlemint, env) => {
+              const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
+              if (!applicationUniqueName) {
+                return missingApplication();
+              }
+              let blockchainNodeUniqueName = blockchainNode;
+              if (!blockchainNodeUniqueName) {
+                const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
+                const node = await blockchainNodePrompt({
+                  env,
+                  nodes: blockchainNodes,
+                  accept: acceptDefaults,
+                  isRequired: true,
                 });
-                return {
-                  result,
-                  mapDefaultEnv: (): Partial<DotEnv> => {
-                    return {
-                      SETTLEMINT_APPLICATION: applicationUniqueName,
-                      SETTLEMINT_HD_PRIVATE_KEY: result.uniqueName,
-                    };
-                  },
-                };
-              },
-            );
-          },
-        );
+                if (!node) {
+                  return nothingSelectedError("blockchain node");
+                }
+                blockchainNodeUniqueName = node.uniqueName;
+              }
+              const result = await settlemint.privateKey.create({
+                name,
+                applicationUniqueName,
+                privateKeyType: "HD_ECDSA_P256",
+                blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
+                provider: "GKE",
+                region: "EUROPE",
+                size: "SMALL",
+                type: "SHARED",
+              });
+              return {
+                result,
+                mapDefaultEnv: (): Partial<DotEnv> => {
+                  return {
+                    SETTLEMINT_APPLICATION: applicationUniqueName,
+                    SETTLEMINT_HD_PRIVATE_KEY: result.uniqueName,
+                  };
+                },
+              };
+            },
+          );
+        });
     },
     examples: [
       {

--- a/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.test.ts
+++ b/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.test.ts
@@ -15,26 +15,12 @@ describe("privateKeyHdCreateCommand", () => {
           commandOptions = options;
         }),
     );
-    program.parse([
-      "node",
-      "test",
-      "hsm-ecdsa-p256",
-      "test-key",
-      "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
-    ]);
+    program.parse(["node", "test", "hsm-ecdsa-p256", "test-key", "--accept-defaults"]);
 
     // Validate command was executed with correct arguments
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 
@@ -56,10 +42,6 @@ describe("privateKeyHdCreateCommand", () => {
       "hsm-ecdsa-p256",
       "test-key",
       "--accept-defaults",
-      "--provider",
-      "gke",
-      "--region",
-      "europe",
       "--application",
       "my-app",
       "--blockchain-node",
@@ -69,12 +51,8 @@ describe("privateKeyHdCreateCommand", () => {
     expect(commandArgs).toBe("test-key");
     expect(commandOptions).toEqual({
       acceptDefaults: true,
-      provider: "gke",
-      region: "europe",
       application: "my-app",
       blockchainNode: "node-1",
-      size: "SMALL",
-      type: "SHARED",
     });
   });
 });

--- a/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.ts
@@ -1,5 +1,4 @@
 import { blockchainNodePrompt } from "@/commands/connect/blockchain-node.prompt";
-import { addClusterServiceArgs } from "@/commands/platform/common/cluster-service.args";
 import { missingApplication } from "@/error/missing-config-error";
 import { nothingSelectedError } from "@/error/nothing-selected-error";
 import { getCreateCommand } from "../../common/create-command";
@@ -16,57 +15,50 @@ export function privateKeyHsmCreateCommand() {
     subType: "HSM-ECDSA-P256",
     alias: "hsm",
     execute: (cmd, baseAction) => {
-      addClusterServiceArgs(cmd)
+      cmd
         .option("--application <application>", "Application unique name")
         .option("--blockchain-node <blockchainNode>", "Blockchain Node unique name")
-        .action(
-          async (
-            name,
-            { application, blockchainNode, provider, region, size, type, acceptDefaults, ...defaultArgs },
-          ) => {
-            return baseAction(
-              {
-                ...defaultArgs,
-                acceptDefaults,
-                provider,
-                region,
-              },
-              async (settlemint, env) => {
-                const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
-                if (!applicationUniqueName) {
-                  return missingApplication();
-                }
-                let blockchainNodeUniqueName = blockchainNode;
-                if (!blockchainNodeUniqueName) {
-                  const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
-                  const node = await blockchainNodePrompt({
-                    env,
-                    nodes: blockchainNodes,
-                    accept: acceptDefaults,
-                    isRequired: true,
-                  });
-                  if (!node) {
-                    return nothingSelectedError("blockchain node");
-                  }
-                  blockchainNodeUniqueName = node.uniqueName;
-                }
-                const result = await settlemint.privateKey.create({
-                  name,
-                  applicationUniqueName,
-                  privateKeyType: "HSM_ECDSA_P256",
-                  blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
-                  provider,
-                  region,
-                  size,
-                  type,
+        .action(async (name, { application, blockchainNode, acceptDefaults, ...defaultArgs }) => {
+          return baseAction(
+            {
+              ...defaultArgs,
+              acceptDefaults,
+            },
+            async (settlemint, env) => {
+              const applicationUniqueName = application ?? env.SETTLEMINT_APPLICATION;
+              if (!applicationUniqueName) {
+                return missingApplication();
+              }
+              let blockchainNodeUniqueName = blockchainNode;
+              if (!blockchainNodeUniqueName) {
+                const blockchainNodes = await settlemint.blockchainNode.list(applicationUniqueName);
+                const node = await blockchainNodePrompt({
+                  env,
+                  nodes: blockchainNodes,
+                  accept: acceptDefaults,
+                  isRequired: true,
                 });
-                return {
-                  result,
-                };
-              },
-            );
-          },
-        );
+                if (!node) {
+                  return nothingSelectedError("blockchain node");
+                }
+                blockchainNodeUniqueName = node.uniqueName;
+              }
+              const result = await settlemint.privateKey.create({
+                name,
+                applicationUniqueName,
+                privateKeyType: "HSM_ECDSA_P256",
+                blockchainNodeUniqueNames: blockchainNodeUniqueName ? [blockchainNodeUniqueName] : [],
+                provider: "GKE",
+                region: "EUROPE",
+                size: "SMALL",
+                type: "SHARED",
+              });
+              return {
+                result,
+              };
+            },
+          );
+        });
     },
     examples: [
       {


### PR DESCRIPTION
- Removed unnecessary parameters from the action handlers in the create commands for accessible ECDSA P256, HD ECDSA P256, and HSM ECDSA P256 private keys.
- Consolidated the command structure to improve readability and maintainability.
- Set default values for provider, region, size, and type directly in the private key creation logic.

This refactor enhances the clarity and efficiency of the private key creation process across different types.

## Summary by Sourcery

Enhancements:
- Simplified the command structure for improved readability and maintainability.