### PR TITLE
fix: codegen all subgraphs when not specified on the connect command

### DIFF
--- a/sdk/cli/src/commands/codegen.ts
+++ b/sdk/cli/src/commands/codegen.ts
@@ -49,7 +49,7 @@ export function codegenCommand(): Command {
         const env: DotEnv = await loadEnv(true, !!prod);
 
         if (!Array.isArray(thegraphSubgraphNames)) {
-          thegraphSubgraphNames = await subgraphNamePrompt(env);
+          thegraphSubgraphNames = await subgraphNamePrompt(env, true);
         }
 
         const { hasura, portal, thegraph, blockscout } = await spinner({

--- a/sdk/cli/src/commands/codegen/subgraph-name.prompt.ts
+++ b/sdk/cli/src/commands/codegen/subgraph-name.prompt.ts
@@ -13,8 +13,8 @@ const ALL = "All";
  * @returns Array of selected subgraph names
  * @throws If no subgraph names are available to select from
  */
-export async function subgraphNamePrompt(env: Partial<DotEnv>): Promise<string[]> {
-  const autoAccept = isInCi;
+export async function subgraphNamePrompt(env: Partial<DotEnv>, accept: boolean | undefined): Promise<string[]> {
+  const autoAccept = isInCi || !!accept;
   const subgraphNames =
     (env.SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS?.map((endpoint) => endpoint.split("/").pop()).filter(
       Boolean,
@@ -33,7 +33,7 @@ export async function subgraphNamePrompt(env: Partial<DotEnv>): Promise<string[]
   }
 
   const subgraphName = await select({
-    message: "Which TheGraphsubgraph do you want to generate types for?",
+    message: "Which The Graph subgraph do you want to generate types for?",
     choices: [ALL, ...subgraphNames].map((name) => ({
       name,
       value: name,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed an issue where codegen would not generate types for all subgraphs when no subgraphs were specified on the connect command.