### PR TITLE
fix: prompt for provider/region when missing

### DIFF
--- a/sdk/cli/src/commands/platform/common/cluster-service.args.ts
+++ b/sdk/cli/src/commands/platform/common/cluster-service.args.ts
@@ -2,14 +2,8 @@ import { type Command, Option, type OptionValues } from "@commander-js/extra-typ
 
 export function addClusterServiceArgs<Args extends OptionValues>(cmd: Command<[string], Args>) {
   return cmd
-    .requiredOption(
-      "--provider <provider>",
-      "Network provider (run `settlemint platform config` to see available providers)",
-    )
-    .requiredOption(
-      "--region <region>",
-      "Deployment region (run `settlemint platform config` to see available regions)",
-    )
+    .option("--provider <provider>", "Network provider (run `settlemint platform config` to see available providers)")
+    .option("--region <region>", "Deployment region (run `settlemint platform config` to see available regions)")
     .addOption(
       new Option("--size <size>", "Network size")
         .choices(["CUSTOM", "LARGE", "MEDIUM", "SMALL"])


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Removed the "required" constraint from the provider and region arguments.