### PR TITLE
fix: improve graphql api error handling

### DIFF
--- a/sdk/utils/src/terminal/spinner.ts
+++ b/sdk/utils/src/terminal/spinner.ts
@@ -47,7 +47,7 @@ export const spinner = async <R>(options: SpinnerOptions<R>): Promise<R> => {
     return result;
   } catch (error) {
     spinner.error(redBright(`${options.startMessage} --> Error!`));
-    note(redBright(`${(error as Error).message}\n${(error as Error).stack}`));
+    note(redBright(`${(error as Error).message}\n\n${(error as Error).stack}`));
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary by Sourcery

Improve error handling in the GraphQL API by parsing and throwing GraphQL errors from the response. Display more informative error messages in the terminal.

Bug Fixes:
- Handle and display GraphQL errors from the API responses.

Enhancements:
- Improve the formatting of error messages displayed in the terminal.