### PR TITLE
fix: ensure recently deployed subgraphs are in the env file

### DIFF
--- a/sdk/cli/src/commands/connect.ts
+++ b/sdk/cli/src/commands/connect.ts
@@ -149,7 +149,7 @@ export function connectCommand(): Command {
           SETTLEMINT_HASURA: hasura?.uniqueName,
           ...getHasuraEndpoints(hasura),
           SETTLEMINT_THEGRAPH: thegraph?.uniqueName,
-          ...(await getGraphEndpoint(settlemint, thegraph, env)),
+          ...(await getGraphEndpoint(settlemint, thegraph)),
           SETTLEMINT_PORTAL: portal?.uniqueName,
           ...getPortalEndpoints(portal),
           SETTLEMINT_HD_PRIVATE_KEY: hdPrivateKey?.uniqueName,

--- a/sdk/cli/src/commands/platform/middleware/graph/create.ts
+++ b/sdk/cli/src/commands/platform/middleware/graph/create.ts
@@ -69,7 +69,7 @@ export function graphMiddlewareCreateCommand() {
                     return {
                       SETTLEMINT_APPLICATION: applicationUniqueName,
                       SETTLEMINT_THEGRAPH: result.uniqueName,
-                      ...(await getGraphEndpoint(settlemint, graphMiddleware, env)),
+                      ...(await getGraphEndpoint(settlemint, graphMiddleware)),
                     };
                   },
                 };

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
@@ -113,7 +113,7 @@ export function subgraphDeployCommand() {
         instance,
       });
       const middleware = await settlemintClient.middleware.read(theGraphMiddleware.uniqueName);
-      const graphEndpoints = await getGraphEndpoint(settlemintClient, middleware, env, graphName);
+      const graphEndpoints = await getGraphEndpoint(settlemintClient, middleware, graphName);
       await writeEnvSpinner(!!prod, {
         ...env,
         SETTLEMINT_THEGRAPH: theGraphMiddleware.uniqueName,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed a bug where starterkit subgraphs were being prioritized over other subgraphs in the environment file, causing incorrect endpoint usage.