### PR TITLE
fix: skip ci on docs commit and use release trigger instead of tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -144,9 +144,8 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' && env.TAG == 'main' }}
         uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
         with:
-          commit_message: "chore: update docs"
+          commit_message: "chore: update docs [skip ci]"
           branch: main
-          push_options: --push-option=ci.skip
           file_pattern: 'sdk/cli/docs/settlemint.md sdk/cli/docs/**/*.md sdk/**/README.md'
 
       - name: Run tests and checks


### PR DESCRIPTION
The '--push-option=ci.skip' seems to be for GitLab only.

So looking at the docs this might work:
https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release

## Summary by Sourcery

Update CI workflow to trigger on release publication and skip CI for documentation commits.

CI:
- Modify CI workflow to trigger on release publication instead of tag push.
- Add '[skip ci]' to commit messages for documentation updates to prevent CI runs.