### PR TITLE
fix: cleanup code docs

### DIFF
--- a/sdk/cli/src/commands/platform/apllication-access-tokens/create.ts
+++ b/sdk/cli/src/commands/platform/apllication-access-tokens/create.ts
@@ -6,7 +6,6 @@ import { getCreateCommand } from "../common/create-command";
 /**
  * Creates and returns the 'application-access-token' command for the SettleMint SDK.
  * This command creates a new application access token for an application.
- * It takes a token name and optional flags.
  */
 export function applicationAccessTokenCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/application/create.ts
+++ b/sdk/cli/src/commands/platform/application/create.ts
@@ -6,7 +6,6 @@ import { getCreateCommand } from "../common/create-command";
 /**
  * Creates and returns the 'application' command for the SettleMint SDK.
  * This command creates a new application in a specified workspace.
- * It takes a workspace name and optional flags.
  */
 export function applicationCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/application/delete.ts
+++ b/sdk/cli/src/commands/platform/application/delete.ts
@@ -4,7 +4,6 @@ import { getDeleteCommand } from "../common/delete-command";
 /**
  * Creates and returns the 'application' command for the SettleMint SDK.
  * This command deletes an application from the SettleMint platform.
- * It takes an application ID or 'default' to delete the default application.
  */
 export function applicationDeleteCommand() {
   return getDeleteCommand({

--- a/sdk/cli/src/commands/platform/common/restart-command.ts
+++ b/sdk/cli/src/commands/platform/common/restart-command.ts
@@ -18,7 +18,7 @@ import type { ResourceType } from "./resource-type";
  * @param options.name - The name of the command
  * @param options.type - The type of resource to restart
  * @param options.alias - Command alias (shorthand)
- * @param options.envKey - Environment variable key for the resource ID
+ * @param options.envKey - Environment variable key for the resource unique name
  * @param options.restartFunction - Function that performs the actual restart operation on the platform
  * @param options.usePersonalAccessToken - Whether to use personal access token for auth (defaults to true)
  * @returns A configured Commander command for restarting the specified resource type
@@ -44,7 +44,7 @@ export function getRestartCommand({
   return new Command(commandName)
     .alias(alias)
     .description(
-      `Restart a ${type} in the SettleMint platform. Provide the ${type} ID or use 'default' to restart the default ${type} from your .env file.`,
+      `Restart a ${type} in the SettleMint platform. Provide the ${type} unique name or use 'default' to restart the default ${type} from your .env file.`,
     )
     .usage(
       createExamples([

--- a/sdk/cli/src/commands/platform/insights/blockscout/create.ts
+++ b/sdk/cli/src/commands/platform/insights/blockscout/create.ts
@@ -9,7 +9,6 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
 /**
  * Creates and returns the 'blockscout' insights command for the SettleMint SDK.
  * This command creates a new Blockscout insights service in the SettleMint platform.
- * It requires an application ID.
  */
 export function blockscoutInsightsCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/integration-tools/hasura/create.test.ts
+++ b/sdk/cli/src/commands/platform/integration-tools/hasura/create.test.ts
@@ -26,7 +26,7 @@ describe("hasuraIntegrationCreateCommand", () => {
     });
   });
 
-  test("executes command with application ID", () => {
+  test("executes command with application unique name", () => {
     let commandOptions: Record<string, unknown> = {};
     let commandArgs = "";
     const program = new Command();

--- a/sdk/cli/src/commands/platform/integration-tools/hasura/create.ts
+++ b/sdk/cli/src/commands/platform/integration-tools/hasura/create.ts
@@ -7,7 +7,6 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
 /**
  * Creates and returns the 'hasura' integration tool command for the SettleMint SDK.
  * This command creates a new Hasura integration in the SettleMint platform.
- * It requires an application ID.
  */
 export function hasuraIntegrationCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/middleware/graph/create.ts
+++ b/sdk/cli/src/commands/platform/middleware/graph/create.ts
@@ -9,7 +9,6 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
 /**
  * Creates and returns the 'graph' middleware command for the SettleMint SDK.
  * This command creates a new graph middleware in the SettleMint platform.
- * It requires an application ID and smart contract set ID.
  */
 export function graphMiddlewareCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/middleware/smart-contract-portal/create.ts
+++ b/sdk/cli/src/commands/platform/middleware/smart-contract-portal/create.ts
@@ -11,7 +11,6 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
 /**
  * Creates and returns the 'smart-contract-portal' middleware command for the SettleMint SDK.
  * This command creates a new smart contract portal middleware in the SettleMint platform.
- * It requires an application ID and smart contract set ID.
  */
 export function smartContractPortalMiddlewareCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/accessible-ecdsa-p256/create.ts
@@ -6,7 +6,6 @@ import { getCreateCommand } from "../../common/create-command";
 /**
  * Creates and returns the 'private-key' command for the SettleMint SDK.
  * This command creates a new HD_ECDSA_P256 private key in the SettleMint platform.
- * It requires an application ID.
  */
 export function privateKeyAccessibleCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/hd-ecdsa-p256/create.ts
@@ -7,7 +7,6 @@ import { getCreateCommand } from "../../common/create-command";
 /**
  * Creates and returns the 'private-key' command for the SettleMint SDK.
  * This command creates a new HD_ECDSA_P256 private key in the SettleMint platform.
- * It requires an application ID.
  */
 export function privateKeyHdCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.ts
+++ b/sdk/cli/src/commands/platform/private-key/hsm-ecdsa-p256/create.ts
@@ -6,7 +6,6 @@ import { getCreateCommand } from "../../common/create-command";
 /**
  * Creates and returns the 'private-key' command for the SettleMint SDK.
  * This command creates a new HSM_ECDSA_P256 private key in the SettleMint platform.
- * It requires an application ID.
  */
 export function privateKeyHsmCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/storage/ipfs/create.ts
+++ b/sdk/cli/src/commands/platform/storage/ipfs/create.ts
@@ -7,7 +7,6 @@ import { getCreateCommand } from "../../common/create-command";
 /**
  * Creates and returns the 'ipfs' storage command for the SettleMint SDK.
  * This command creates a new IPFS storage in the SettleMint platform.
- * It requires an application ID.
  */
 export function ipfsStorageCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/storage/minio/create.ts
+++ b/sdk/cli/src/commands/platform/storage/minio/create.ts
@@ -7,7 +7,6 @@ import { getCreateCommand } from "../../common/create-command";
 /**
  * Creates and returns the 'minio' storage command for the SettleMint SDK.
  * This command creates a new MinIO storage in the SettleMint platform.
- * It requires an application ID.
  */
 export function minioStorageCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/workspace/create.ts
+++ b/sdk/cli/src/commands/platform/workspace/create.ts
@@ -5,7 +5,6 @@ import { getCreateCommand } from "../common/create-command";
 /**
  * Creates and returns the 'workspace' command for the SettleMint SDK.
  * This command creates a new workspace in the SettleMint platform.
- * It takes a name and optional description for the workspace.
  */
 export function workspaceCreateCommand() {
   return getCreateCommand({

--- a/sdk/cli/src/commands/platform/workspace/delete.ts
+++ b/sdk/cli/src/commands/platform/workspace/delete.ts
@@ -3,7 +3,6 @@ import { getDeleteCommand } from "@/commands/platform/common/delete-command";
 /**
  * Creates and returns the 'workspace' command for the SettleMint SDK.
  * This command creates a new workspace in the SettleMint platform.
- * It takes a name and optional description for the workspace.
  */
 export function workspaceDeleteCommand() {
   return getDeleteCommand({


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Clarify the CLI help text to reflect the use of unique names instead of IDs.