### PR TITLE
fix: remove storing default instance in .config

### DIFF
--- a/sdk/cli/src/commands/login.ts
+++ b/sdk/cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import { instancePrompt } from "@/prompts/instance.prompt";
 import { personalAccessTokenPrompt } from "@/prompts/pat.prompt";
 import { loginSpinner } from "@/spinners/login.spinner";
 import { createExamples } from "@/utils/commands/create-examples";
-import { setDefaultInstance, storeCredentials } from "@/utils/config";
+import { storeCredentials } from "@/utils/config";
 import { sanitizeAndValidateInstanceUrl } from "@/utils/instance-url-utils";
 import { Command } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
@@ -33,10 +33,9 @@ export function loginCommand(): Command {
       ]),
     )
     .option("-a, --accept-defaults", "Accept the default and previously set values")
-    .option("-d, --default", "Set this instance as the default")
     .option("--token-stdin", "Provide a token using STDIN")
     .option("-i, --instance <instance>", "The instance to login to (defaults to the instance in the .env file)")
-    .action(async ({ acceptDefaults, default: isDefault, tokenStdin, instance }, cmd) => {
+    .action(async ({ acceptDefaults, tokenStdin, instance }, cmd) => {
       intro("Login to your SettleMint account");
       const autoAccept = !!acceptDefaults || !!tokenStdin;
       const env = await loadEnv(false, false);
@@ -83,10 +82,6 @@ export function loginCommand(): Command {
 
       // If we get here, the connection was successful
       await storeCredentials(personalAccessToken, selectedInstance);
-
-      if (isDefault) {
-        await setDefaultInstance(selectedInstance);
-      }
 
       outro("Successfully logged in to SettleMint!");
     });

--- a/sdk/cli/src/commands/logout.ts
+++ b/sdk/cli/src/commands/logout.ts
@@ -1,7 +1,9 @@
 import { getInstances, removeCredentials } from "@/utils/config";
 import { Command } from "@commander-js/extra-typings";
 import select from "@inquirer/select";
+import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { intro, outro } from "@settlemint/sdk-utils/terminal";
+import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 /**
  * Creates and returns the 'logout' command for the SettleMint SDK CLI.
@@ -38,11 +40,14 @@ export function logoutCommand(): Command {
       }
 
       // Let user select which instance to logout from
+      const env: Partial<DotEnv> = await loadEnv(false, false);
+      const defaultInstance = env.SETTLEMINT_INSTANCE;
       const instance = await select({
         message: "Select the instance to logout from:",
         choices: instances.map((instance) => ({
           value: instance,
           label: instance,
+          description: defaultInstance && instance === defaultInstance ? "(default)" : undefined,
         })),
       });
 

--- a/sdk/cli/src/commands/logout.ts
+++ b/sdk/cli/src/commands/logout.ts
@@ -1,4 +1,4 @@
-import { getDefaultInstance, getInstances, removeCredentials } from "@/utils/config";
+import { getInstances, removeCredentials } from "@/utils/config";
 import { Command } from "@commander-js/extra-typings";
 import select from "@inquirer/select";
 import { intro, outro } from "@settlemint/sdk-utils/terminal";
@@ -38,13 +38,11 @@ export function logoutCommand(): Command {
       }
 
       // Let user select which instance to logout from
-      const defaultInstance = await getDefaultInstance();
       const instance = await select({
         message: "Select the instance to logout from:",
         choices: instances.map((instance) => ({
           value: instance,
           label: instance,
-          description: instance === defaultInstance ? "(default)" : undefined,
         })),
       });
 

--- a/sdk/cli/src/prompts/instance.prompt.ts
+++ b/sdk/cli/src/prompts/instance.prompt.ts
@@ -33,7 +33,8 @@ export async function instancePrompt(
     return sanitizeInstanceUrl(defaultInstance);
   }
 
-  const defaultPromptInstance = defaultInstance ?? "https://console.settlemint.com";
+  const defaultPromptInstance =
+    defaultInstance ?? (knownInstances.length > 0 ? knownInstances[0] : "https://console.settlemint.com");
 
   if (isCi) {
     return sanitizeInstanceUrl(defaultPromptInstance);

--- a/sdk/cli/src/prompts/instance.prompt.ts
+++ b/sdk/cli/src/prompts/instance.prompt.ts
@@ -1,4 +1,4 @@
-import { getDefaultInstance, getInstances } from "@/utils/config";
+import { getInstances } from "@/utils/config";
 import { sanitizeInstanceUrl } from "@/utils/instance-url-utils";
 import input from "@inquirer/input";
 import select from "@inquirer/select";
@@ -33,8 +33,7 @@ export async function instancePrompt(
     return sanitizeInstanceUrl(defaultInstance);
   }
 
-  const defaultLoginInstance = await getDefaultInstance();
-  const defaultPromptInstance = defaultInstance ?? defaultLoginInstance ?? "https://console.settlemint.com";
+  const defaultPromptInstance = defaultInstance ?? "https://console.settlemint.com";
 
   if (isCi) {
     return sanitizeInstanceUrl(defaultPromptInstance);

--- a/sdk/cli/src/utils/config.ts
+++ b/sdk/cli/src/utils/config.ts
@@ -15,7 +15,6 @@ interface InstanceConfig {
 
 interface Config {
   instances: Record<string, InstanceConfig>;
-  defaultInstance?: string;
 }
 
 /**
@@ -66,11 +65,6 @@ export async function storeCredentials(token: string, instance: string): Promise
     lastUsed: new Date().toISOString(),
   };
 
-  // If this is the first instance or there's no default, set it as default
-  if (!config.defaultInstance || Object.keys(config.instances).length === 1) {
-    config.defaultInstance = instance;
-  }
-
   await writeConfig(config);
 }
 
@@ -107,26 +101,6 @@ export async function getInstances(): Promise<string[]> {
 }
 
 /**
- * Gets the default instance if one is set
- */
-export async function getDefaultInstance(): Promise<string | undefined> {
-  const config = await readConfig();
-  return config.defaultInstance;
-}
-
-/**
- * Sets the default instance
- */
-export async function setDefaultInstance(instance: string): Promise<void> {
-  const config = await readConfig();
-  if (!config.instances[instance]) {
-    throw new Error(`Instance ${instance} is not configured`);
-  }
-  config.defaultInstance = instance;
-  await writeConfig(config);
-}
-
-/**
  * Removes credentials for a specific instance
  */
 export async function removeCredentials(instance: string): Promise<void> {
@@ -134,11 +108,6 @@ export async function removeCredentials(instance: string): Promise<void> {
 
   // Remove from config file
   delete config.instances[instance];
-
-  // If this was the default instance, clear it
-  if (config.defaultInstance === instance) {
-    config.defaultInstance = undefined;
-  }
 
   await writeConfig(config);
 }


### PR DESCRIPTION
## Summary by Sourcery

Remove the concept of a default instance.

Enhancements:
- Simplify the login and logout flows.

Chores:
- Store last used instance in the environment file instead of the config file.