### PR TITLE
fix: default deployer address not activated on default node

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -65,11 +65,5 @@ export async function selectTargetNode({
     serviceNotRunningError("blockchain node", node.status);
   }
 
-  if (node.privateKeys?.length === 0) {
-    cancel(
-      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${nodeUniqueName}'. Please activate a private key on this node or specify a different node.`,
-    );
-  }
-
   return node;
 }

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -65,6 +65,6 @@ export async function selectTargetNode({
     serviceNotRunningError("blockchain node", node.status);
   }
 
-  note(`Using blockchain node ${node.uniqueName}`);
+  note(`Using blockchain node '${node.uniqueName}'`);
   return node;
 }

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -4,7 +4,7 @@ import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
 import type { BlockchainNode, SettlemintClient } from "@settlemint/sdk-js";
-import { cancel } from "@settlemint/sdk-utils/terminal";
+import { cancel, note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 export async function selectTargetNode({
@@ -65,5 +65,6 @@ export async function selectTargetNode({
     serviceNotRunningError("blockchain node", node.status);
   }
 
+  note(`Using blockchain node ${node.uniqueName}`);
   return node;
 }

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -67,7 +67,7 @@ export async function selectTargetNode({
 
   if (node.privateKeys?.length === 0) {
     cancel(
-      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${nodeUniqueName}'. Please activate a private key on the node or specify a different node.`,
+      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${nodeUniqueName}'. Please activate a private key on this node or specify a different node.`,
     );
   }
 

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -4,7 +4,7 @@ import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
 import type { BlockchainNode, SettlemintClient } from "@settlemint/sdk-js";
-import { cancel, note } from "@settlemint/sdk-utils/terminal";
+import { cancel } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 export async function selectTargetNode({
@@ -56,7 +56,7 @@ export async function selectTargetNode({
     node = await settlemint.blockchainNode.read(nodeUniqueName);
     if (!node.isEvm) {
       cancel(
-        "The specified blockchain node is not an EVM blockchain node. Please specify an EVM blockchain node to continue.",
+        `The specified blockchain node '${nodeUniqueName}' is not an EVM blockchain node. Please specify an EVM blockchain node to continue.`,
       );
     }
   }
@@ -65,6 +65,11 @@ export async function selectTargetNode({
     serviceNotRunningError("blockchain node", node.status);
   }
 
-  note(`Using blockchain node '${node.uniqueName}'`);
+  if (node.privateKeys?.length === 0) {
+    cancel(
+      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${nodeUniqueName}'. Please activate a private key on the node or specify a different node.`,
+    );
+  }
+
   return node;
 }

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -2,7 +2,7 @@ import { writeEnvSpinner } from "@/spinners/write-env.spinner";
 import type { HardhatConfig } from "@/utils/smart-contract-set/hardhat-config";
 import select from "@inquirer/select";
 import type { BlockchainNode } from "@settlemint/sdk-js";
-import { cancel } from "@settlemint/sdk-utils/terminal";
+import { cancel, note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 /**
@@ -58,6 +58,6 @@ export async function addressPrompt({
       SETTLEMINT_SMART_CONTRACT_ADDRESS: address,
     });
   }
-
+  note(`Deploying from ${address}`);
   return address;
 }

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -35,13 +35,15 @@ export async function addressPrompt({
     env.SETTLEMINT_SMART_CONTRACT_ADDRESS ?? hardhatConfig.networks?.btp?.from ?? possiblePrivateKeys[0]?.address;
   const defaultPossible = accept && defaultAddress;
 
-  note(`env.SETTLEMINT_SMART_CONTRACT_ADDRESS: '${env.SETTLEMINT_SMART_CONTRACT_ADDRESS}'`);
-  note(`hardhatConfig.networks?.btp?.from: '${hardhatConfig.networks?.btp?.from}'`);
-  note(`possiblePrivateKeys[0]?.address: '${possiblePrivateKeys[0]?.address}'`);
-
   if (defaultPossible) {
-    note(`Deploying from '${defaultAddress}'`);
-    return defaultAddress;
+    if (node.privateKeys?.some((privateKey) => privateKey.address === defaultAddress)) {
+      return defaultAddress;
+    }
+
+    note(
+      `Private key with address '${defaultAddress}' not activated on the node '${node.uniqueName}'.\nPlease select another key or activate this key on the node and try again.`,
+      "warn",
+    );
   }
 
   if (possiblePrivateKeys.length === 0) {
@@ -63,6 +65,6 @@ export async function addressPrompt({
       SETTLEMINT_SMART_CONTRACT_ADDRESS: address,
     });
   }
-  note(`Deploying from '${address}'`);
+
   return address;
 }

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -35,7 +35,12 @@ export async function addressPrompt({
     env.SETTLEMINT_SMART_CONTRACT_ADDRESS ?? hardhatConfig.networks?.btp?.from ?? possiblePrivateKeys[0]?.address;
   const defaultPossible = accept && defaultAddress;
 
+  note(`env.SETTLEMINT_SMART_CONTRACT_ADDRESS: '${env.SETTLEMINT_SMART_CONTRACT_ADDRESS}'`);
+  note(`hardhatConfig.networks?.btp?.from: '${hardhatConfig.networks?.btp?.from}'`);
+  note(`possiblePrivateKeys[0]?.address: '${possiblePrivateKeys[0]?.address}'`);
+
   if (defaultPossible) {
+    note(`Deploying from '${defaultAddress}'`);
     return defaultAddress;
   }
 
@@ -58,6 +63,6 @@ export async function addressPrompt({
       SETTLEMINT_SMART_CONTRACT_ADDRESS: address,
     });
   }
-  note(`Deploying from ${address}`);
+  note(`Deploying from '${address}'`);
   return address;
 }

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -35,8 +35,14 @@ export async function addressPrompt({
     env.SETTLEMINT_SMART_CONTRACT_ADDRESS ?? hardhatConfig.networks?.btp?.from ?? possiblePrivateKeys[0]?.address;
   const defaultPossible = accept && defaultAddress;
 
+  if (!node.privateKeys || node.privateKeys.length === 0) {
+    cancel(
+      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${node.uniqueName}'. Please activate a private key on this node or specify a different node.`,
+    );
+  }
+
   if (defaultPossible) {
-    if (node.privateKeys?.some((privateKey) => privateKey.address === defaultAddress)) {
+    if (node.privateKeys.some((privateKey) => privateKey.address?.toLowerCase() === defaultAddress?.toLowerCase())) {
       return defaultAddress;
     }
 
@@ -44,10 +50,6 @@ export async function addressPrompt({
       `Private key with address '${defaultAddress}' not activated on the node '${node.uniqueName}'.\nPlease select another key or activate this key on the node and try again.`,
       "warn",
     );
-  }
-
-  if (possiblePrivateKeys.length === 0) {
-    cancel("No ECDSA P256 or HSM ECDSA P256 private key is activated on the node to sign the transaction.");
   }
 
   const address = await select({


### PR DESCRIPTION
I ended up in the situation where the default pk in the env file was not activated on the default node in the env file, and there was no pk activated on the default node in the env file. So added checks to:
- Ensure there is a pk activated on the node even when we have a default pk entered
- Ensure default pk is activated on the node

<img width="1810" alt="image" src="https://github.com/user-attachments/assets/cf247685-7b31-45aa-bac4-fae00c141e4b" />


<img width="1759" alt="image" src="https://github.com/user-attachments/assets/8d2ac330-5b75-4e6b-b601-203b0a17890b" />
