### PR TITLE
fix: command docs

### DIFF
--- a/scripts/templates/README-template.md
+++ b/scripts/templates/README-template.md
@@ -42,7 +42,7 @@
 {{/api-reference}}
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/blockscout/README.md
+++ b/sdk/blockscout/README.md
@@ -175,7 +175,7 @@ Defines two possible runtime configurations:
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/cli/README.md
+++ b/sdk/cli/README.md
@@ -253,7 +253,7 @@ See the [documentation](https://github.com/settlemint/sdk/tree/v1.0.6/sdk/cli/do
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/cli/docs/settlemint/platform/list.md
+++ b/sdk/cli/docs/settlemint/platform/list.md
@@ -18,25 +18,25 @@ Commands:
 Examples:
 
   # List the application services
-  $ settlemint settlemint platform application get
+  $ settlemint platform list services
 
   # List the application services in wide format with more information (such as console url)
-  $ settlemint settlemint platform application get -o wide
+  $ settlemint platform list services -o wide
 
   # List the application services in JSON format
-  $ settlemint settlemint platform application get -o json &gt; services.json
+  $ settlemint platform list services -o json &gt; services.json
 
   # List the application services in YAML format
-  $ settlemint settlemint platform application get -o yaml &gt; services.yaml
+  $ settlemint platform list services -o yaml &gt; services.yaml
 
   # List the application services for a specific application
-  $ settlemint settlemint platform application get --application my-app
+  $ settlemint platform list services --application my-app
 
   # List the application services for a specific application and type
-  $ settlemint settlemint platform application get --application my-app --type middleware
+  $ settlemint platform list services --application my-app --type middleware
 
   # List the application services for multiple types
-  $ settlemint settlemint platform application get --type blockchain-network blockchain-node middleware
+  $ settlemint platform list services --type blockchain-network blockchain-node middleware
 
 List the application services
 

--- a/sdk/cli/src/commands/platform/application/services.ts
+++ b/sdk/cli/src/commands/platform/application/services.ts
@@ -40,31 +40,31 @@ export function servicesCommand() {
       createExamples([
         {
           description: "List the application services",
-          command: "settlemint platform application get",
+          command: "platform list services",
         },
         {
           description: "List the application services in wide format with more information (such as console url)",
-          command: "settlemint platform application get -o wide",
+          command: "platform list services -o wide",
         },
         {
           description: "List the application services in JSON format",
-          command: "settlemint platform application get -o json > services.json",
+          command: "platform list services -o json > services.json",
         },
         {
           description: "List the application services in YAML format",
-          command: "settlemint platform application get -o yaml > services.yaml",
+          command: "platform list services -o yaml > services.yaml",
         },
         {
           description: "List the application services for a specific application",
-          command: "settlemint platform application get --application my-app",
+          command: "platform list services --application my-app",
         },
         {
           description: "List the application services for a specific application and type",
-          command: "settlemint platform application get --application my-app --type middleware",
+          command: "platform list services --application my-app --type middleware",
         },
         {
           description: "List the application services for multiple types",
-          command: "settlemint platform application get --type blockchain-network blockchain-node middleware",
+          command: "platform list services --type blockchain-network blockchain-node middleware",
         },
       ]),
     )

--- a/sdk/hasura/README.md
+++ b/sdk/hasura/README.md
@@ -219,7 +219,7 @@ Defines two possible runtime configurations:
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/ipfs/README.md
+++ b/sdk/ipfs/README.md
@@ -138,7 +138,7 @@ console.log(result.cid.toString());
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -254,7 +254,7 @@ Type representing a workspace entity.
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/minio/README.md
+++ b/sdk/minio/README.md
@@ -91,7 +91,7 @@ client.listBuckets();
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/next/README.md
+++ b/sdk/next/README.md
@@ -159,7 +159,7 @@ Options for configuring the SettleMint configuration.
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/portal/README.md
+++ b/sdk/portal/README.md
@@ -171,7 +171,7 @@ Discriminates between server and browser runtime environments.
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/thegraph/README.md
+++ b/sdk/thegraph/README.md
@@ -179,7 +179,7 @@ Defines two possible runtime configurations:
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 

--- a/sdk/utils/README.md
+++ b/sdk/utils/README.md
@@ -1773,7 +1773,7 @@ const isInvalidUrl = UrlSchema.safeParse("not-a-url").success;
 
 ## Contributing
 
-We welcome contributions from the community! Please check out our [Contributing](../../.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
+We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.
 
 ## License
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the command name for listing platform services in the documentation and examples.