### PR TITLE
fix: gha job permissions in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ on:
   schedule:
     - cron: '30 22 * * 4'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Grant read-all permissions to the CodeQL analysis workflow.