### PR TITLE
fix: show single option selected msg for remote deploy

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -4,7 +4,7 @@ import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
 import type { BlockchainNode, SettlemintClient } from "@settlemint/sdk-js";
-import { cancel } from "@settlemint/sdk-utils/terminal";
+import { cancel, note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 export async function selectTargetNode({
@@ -47,6 +47,8 @@ export async function selectTargetNode({
       nodes: nodesWithActivePrivateKey,
       accept: autoAccept,
       isRequired: true,
+      singleOptionMessage: (node) =>
+        `Using '${node}' - the only node with active private keys. To use a different node, ensure it has activated private keys.`,
     });
     if (!blockchainNode) {
       return nothingSelectedError("EVM blockchain node");
@@ -65,5 +67,6 @@ export async function selectTargetNode({
     serviceNotRunningError("blockchain node", node.status);
   }
 
+  note(`🔗 Connected to blockchain node '${node.uniqueName}'`);
   return node;
 }

--- a/sdk/cli/src/prompts/cluster-service/blockchain-network.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/blockchain-network.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { BlockchainNetwork } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface BlockchainNetworkPromptArgs extends BaseServicePromptArgs<BlockchainNetwork> {
+  networks: BlockchainNetwork[];
+}
 
 /**
  * Prompts the user to select a blockchain network to connect to.
@@ -18,12 +21,7 @@ export async function blockchainNetworkPrompt({
   networks,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  networks: BlockchainNetwork[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<BlockchainNetwork | undefined> {
+}: BlockchainNetworkPromptArgs): Promise<BlockchainNetwork | undefined> {
   return servicePrompt({
     env,
     services: networks,

--- a/sdk/cli/src/prompts/cluster-service/blockchain-node.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/blockchain-node.prompt.ts
@@ -1,7 +1,14 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { BlockchainNode } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+/**
+ * Arguments for the blockchain node prompt.
+ */
+export interface BlockchainNodePromptArgs extends BaseServicePromptArgs<BlockchainNode> {
+  nodes: BlockchainNode[];
+  filterRunningOnly?: boolean;
+}
 
 /**
  * Prompts the user to select a blockchain node to connect to.
@@ -18,15 +25,10 @@ export async function blockchainNodePrompt({
   env,
   nodes,
   accept,
+  singleOptionMessage,
   filterRunningOnly = false,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  nodes: BlockchainNode[];
-  accept: boolean | undefined;
-  filterRunningOnly?: boolean;
-  isRequired?: boolean;
-}): Promise<BlockchainNode | undefined> {
+}: BlockchainNodePromptArgs): Promise<BlockchainNode | undefined> {
   return servicePrompt({
     env,
     services: nodes,
@@ -43,5 +45,6 @@ export async function blockchainNodePrompt({
         default: defaultNode,
       });
     },
+    singleOptionMessage,
   });
 }

--- a/sdk/cli/src/prompts/cluster-service/blockscout.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/blockscout.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { Insights } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface BlockscoutPromptArgs extends BaseServicePromptArgs<Insights> {
+  insights: Insights[];
+}
 
 /**
  * Prompts the user to select a blockscout service to connect to.
@@ -18,12 +21,7 @@ export async function blockscoutPrompt({
   insights,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  insights: Insights[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<Insights | undefined> {
+}: BlockscoutPromptArgs): Promise<Insights | undefined> {
   const possible = insights.filter((insight) => insight.insightsCategory === "BLOCKCHAIN_EXPLORER");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/custom-deployment.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/custom-deployment.prompt.ts
@@ -1,7 +1,10 @@
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { CustomDeployment } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
-import { servicePrompt } from "./service.prompt";
+
+export interface CustomDeploymentPromptArgs extends BaseServicePromptArgs<CustomDeployment> {
+  customDeployments: CustomDeployment[];
+}
 
 /**
  * Prompts the user to select a custom deployment to connect to.
@@ -18,12 +21,7 @@ export async function customDeploymentPrompt({
   customDeployments,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  customDeployments: CustomDeployment[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<CustomDeployment | undefined> {
+}: CustomDeploymentPromptArgs): Promise<CustomDeployment | undefined> {
   return servicePrompt({
     env,
     services: customDeployments,

--- a/sdk/cli/src/prompts/cluster-service/hasura.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/hasura.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { IntegrationTool } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface HasuraPromptArgs extends BaseServicePromptArgs<IntegrationTool> {
+  integrations: IntegrationTool[];
+}
 
 /**
  * Prompts the user to select a Hasura instance to connect to.
@@ -18,12 +21,7 @@ export async function hasuraPrompt({
   integrations,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  integrations: IntegrationTool[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<IntegrationTool | undefined> {
+}: HasuraPromptArgs): Promise<IntegrationTool | undefined> {
   const possible = integrations.filter((integration) => integration.integrationType === "HASURA");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/hd-private-keys.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/hd-private-keys.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { PrivateKey } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface HdPrivateKeyPromptArgs extends BaseServicePromptArgs<PrivateKey> {
+  privateKeys: PrivateKey[];
+}
 
 /**
  * Prompts the user to select an HD private key to use.
@@ -18,12 +21,7 @@ export async function hdPrivateKeyPrompt({
   privateKeys,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  privateKeys: PrivateKey[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<PrivateKey | undefined> {
+}: HdPrivateKeyPromptArgs): Promise<PrivateKey | undefined> {
   const possible = privateKeys.filter((privateKey) => privateKey.privateKeyType === "HD_ECDSA_P256");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/ipfs.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/ipfs.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { Storage } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface IpfsPromptArgs extends BaseServicePromptArgs<Storage> {
+  storages: Storage[];
+}
 
 /**
  * Prompts the user to select an IPFS storage instance to connect to.
@@ -18,12 +21,7 @@ export async function ipfsPrompt({
   storages,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  storages: Storage[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<Storage | undefined> {
+}: IpfsPromptArgs): Promise<Storage | undefined> {
   const possible = storages.filter((storage) => storage.storageProtocol === "IPFS");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/minio.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/minio.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { Storage } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface MinioPromptArgs extends BaseServicePromptArgs<Storage> {
+  storages: Storage[];
+}
 
 /**
  * Prompts the user to select a MinIO storage instance to connect to.
@@ -18,12 +21,7 @@ export async function minioPrompt({
   storages,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  storages: Storage[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<Storage | undefined> {
+}: MinioPromptArgs): Promise<Storage | undefined> {
   const possible = storages.filter((storage) => storage.storageProtocol === "MINIO");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/portal.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/portal.prompt.ts
@@ -1,7 +1,10 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { Middleware } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface PortalPromptArgs extends BaseServicePromptArgs<Middleware> {
+  middlewares: Middleware[];
+}
 
 /**
  * Prompts the user to select a Smart Contract Portal instance to connect to.
@@ -18,12 +21,7 @@ export async function portalPrompt({
   middlewares,
   accept,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  middlewares: Middleware[];
-  accept: boolean | undefined;
-  isRequired?: boolean;
-}): Promise<Middleware | undefined> {
+}: PortalPromptArgs): Promise<Middleware | undefined> {
   const possible = middlewares.filter((middleware) => middleware.interface === "SMART_CONTRACT_PORTAL");
   return servicePrompt({
     env,

--- a/sdk/cli/src/prompts/cluster-service/service.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/service.prompt.ts
@@ -1,3 +1,4 @@
+import { note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
@@ -9,6 +10,30 @@ export interface Choice<Service> {
   value: Service | undefined;
 }
 
+/**
+ * Base arguments for the service prompt.
+ */
+export interface BaseServicePromptArgs<Service> {
+  env: Partial<DotEnv>;
+
+  accept: boolean | undefined;
+
+  isRequired?: boolean;
+  isCi?: boolean;
+  singleOptionMessage?: (selectedService: string) => string;
+}
+
+/**
+ * Arguments for the service prompt.
+ */
+export interface ServicePromptArgs<Service> extends BaseServicePromptArgs<Service> {
+  services: Service[];
+  defaultHandler: (config: {
+    defaultService: Service | undefined;
+    choices: Choice<Service>[];
+  }) => Promise<Service | undefined>;
+  envKey: keyof DotEnv;
+}
 /**
  * Prompts the user to select a service from a list of available services.
  *
@@ -30,18 +55,8 @@ export async function servicePrompt<Service extends { uniqueName: string; name: 
   defaultHandler,
   isRequired = false,
   isCi = isInCi,
-}: {
-  env: Partial<DotEnv>;
-  services: Service[];
-  accept: boolean | undefined;
-  envKey: keyof DotEnv;
-  defaultHandler: (config: {
-    defaultService: Service | undefined;
-    choices: Choice<Service>[];
-  }) => Promise<Service | undefined>;
-  isRequired?: boolean;
-  isCi?: boolean;
-}): Promise<Service | undefined> {
+  singleOptionMessage,
+}: ServicePromptArgs<Service>) {
   // Return early if no services available
   if (services.length === 0) {
     return undefined;
@@ -63,6 +78,9 @@ export async function servicePrompt<Service extends { uniqueName: string; name: 
 
   // Auto-select if only one service available and a service is required
   if (isRequired && services.length === 1) {
+    if (singleOptionMessage) {
+      note(singleOptionMessage(services[0].uniqueName));
+    }
     return services[0];
   }
 

--- a/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
@@ -1,7 +1,11 @@
-import { servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
 import select from "@inquirer/select";
 import type { Middleware } from "@settlemint/sdk-js";
-import type { DotEnv } from "@settlemint/sdk-utils/validation";
+
+export interface TheGraphPromptArgs extends BaseServicePromptArgs<Middleware> {
+  middlewares: Middleware[];
+  filterRunningOnly?: boolean;
+}
 
 /**
  * Prompts the user to select a The Graph instance to connect to.
@@ -20,13 +24,7 @@ export async function theGraphPrompt({
   accept,
   filterRunningOnly = false,
   isRequired = false,
-}: {
-  env: Partial<DotEnv>;
-  middlewares: Middleware[];
-  accept?: boolean;
-  filterRunningOnly?: boolean;
-  isRequired?: boolean;
-}) {
+}: TheGraphPromptArgs): Promise<Middleware | undefined> {
   const graphMiddlewares = middlewares.filter((middleware) => middleware.__typename === "HAGraphMiddleware");
   return servicePrompt({
     env,


### PR DESCRIPTION
Was not clear why I wasn't able to deploy contracts on my new node, turns out I had forgotten to activate a private key on it, so i've added a message for remote deploy to highlight when we have only one node with activated PKs which is auto selected:

<img width="1767" alt="image" src="https://github.com/user-attachments/assets/e5801ebf-60d0-4075-9e48-74dccd1b3c41" />
