### PR TITLE
feat: add --output option to platform config command

### DIFF
--- a/sdk/cli/src/commands/platform/application/list.ts
+++ b/sdk/cli/src/commands/platform/application/list.ts
@@ -6,12 +6,13 @@ import { workspaceSpinner } from "@/spinners/workspaces.spinner";
 import { createExamples } from "@/utils/commands/create-examples";
 import { getInstanceCredentials } from "@/utils/config";
 import { getApplicationUrl, getWorkspaceUrl } from "@/utils/get-platform-url";
+import { jsonOutput } from "@/utils/output/json-output";
+import { yamlOutput } from "@/utils/output/yaml-output";
 import { Command, Option } from "@commander-js/extra-typings";
 import { type SettlemintClient, createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { intro, outro, table } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
-import { stringify } from "yaml";
 
 export function applicationsListCommand() {
   return new Command("applications")
@@ -87,9 +88,9 @@ export function applicationsListCommand() {
           applicationsData,
         );
       } else if (output === "json") {
-        console.log(JSON.stringify(applicationsData, null, 2));
+        jsonOutput(applicationsData);
       } else if (output === "yaml") {
-        console.log(stringify(applicationsData));
+        yamlOutput(applicationsData);
       }
 
       if (printToTerminal) {

--- a/sdk/cli/src/commands/platform/application/services.ts
+++ b/sdk/cli/src/commands/platform/application/services.ts
@@ -11,13 +11,14 @@ import { workspaceSpinner } from "@/spinners/workspaces.spinner";
 import { createExamples } from "@/utils/commands/create-examples";
 import { getInstanceCredentials } from "@/utils/config";
 import { getApplicationUrl, getClusterServicePlatformUrl, getWorkspaceUrl } from "@/utils/get-platform-url";
+import { jsonOutput } from "@/utils/output/json-output";
+import { yamlOutput } from "@/utils/output/yaml-output";
 import { Command, Option } from "@commander-js/extra-typings";
 import { type SettlemintClient, createSettleMintClient } from "@settlemint/sdk-js";
 import { capitalizeFirstLetter } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { intro, outro, table } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
-import { stringify } from "yaml";
 import { formatHealthStatus } from "../utils/formatting/format-health-status";
 import { formatStatus } from "../utils/formatting/format-status";
 
@@ -129,9 +130,9 @@ export function servicesCommand() {
           servicesToShow,
         );
       } else if (output === "json") {
-        console.log(JSON.stringify(data, null, 2));
+        jsonOutput(data);
       } else if (output === "yaml") {
-        console.log(stringify(data));
+        yamlOutput(data);
       }
       if (printToTerminal) {
         outro("Application services listed");

--- a/sdk/cli/src/commands/platform/config.test.ts
+++ b/sdk/cli/src/commands/platform/config.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { sdkCliCommand } from "@/commands";
+import { jsonOutput } from "@/utils/output/json-output";
+import { yamlOutput } from "@/utils/output/yaml-output";
+import { table } from "@settlemint/sdk-utils/terminal";
+
+const mockTable = mock(table);
+
+// Mock terminal module
+mock.module("@settlemint/sdk-utils/terminal", () => ({
+  table: mockTable,
+}));
+
+const mockJsonOutput = mock(jsonOutput);
+
+mock.module("@/utils/output/json-output", () => ({
+  jsonOutput: mockJsonOutput,
+}));
+
+const mockYamlOutput = mock(yamlOutput);
+
+mock.module("@/utils/output/yaml-output", () => ({
+  yamlOutput: mockYamlOutput,
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("platform config command", () => {
+  beforeEach(() => {
+    mockTable.mockClear();
+    mockJsonOutput.mockClear();
+    mockYamlOutput.mockClear();
+  });
+
+  test("should output platform configuration", async () => {
+    await sdkCliCommand(["bun", "settlemint", "platform", "config", "-i", "https://console.settlemint.com"]);
+    expect(mockTable).toHaveBeenCalledTimes(3);
+    expect(mockJsonOutput).not.toHaveBeenCalled();
+    expect(mockYamlOutput).not.toHaveBeenCalled();
+  });
+
+  test("should output platform configuration in json format", async () => {
+    await sdkCliCommand([
+      "bun",
+      "settlemint",
+      "platform",
+      "config",
+      "-i",
+      "https://console.settlemint.com",
+      "-o",
+      "json",
+    ]);
+    expect(mockTable).not.toHaveBeenCalled();
+    expect(mockJsonOutput).toHaveBeenCalled();
+    expect(mockYamlOutput).not.toHaveBeenCalled();
+  });
+
+  test("should output platform configuration in yaml format", async () => {
+    await sdkCliCommand([
+      "bun",
+      "settlemint",
+      "platform",
+      "config",
+      "-i",
+      "https://console.settlemint.com",
+      "-o",
+      "yaml",
+    ]);
+    expect(mockTable).not.toHaveBeenCalled();
+    expect(mockJsonOutput).not.toHaveBeenCalled();
+    expect(mockYamlOutput).toHaveBeenCalled();
+  });
+});

--- a/sdk/cli/src/commands/platform/config.ts
+++ b/sdk/cli/src/commands/platform/config.ts
@@ -1,8 +1,10 @@
 import { instancePrompt } from "@/prompts/instance.prompt";
 import { getRegionId } from "@/utils/cluster-region";
 import { sanitizeAndValidateInstanceUrl } from "@/utils/instance-url-utils";
+import { jsonOutput } from "@/utils/output/json-output";
+import { yamlOutput } from "@/utils/output/yaml-output";
 import { getStarterkits, getUseCases } from "@/utils/platform-utils";
-import { Command } from "@commander-js/extra-typings";
+import { Command, Option } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { intro, list, outro, table } from "@settlemint/sdk-utils/terminal";
@@ -18,8 +20,12 @@ export function configCommand() {
     .description("Get platform configuration")
     .option("--prod", "Connect to your production environment")
     .option("-i, --instance <instance>", "The instance to connect to (defaults to the instance in the .env file)")
-    .action(async ({ prod, instance }) => {
-      intro("Getting platform configuration");
+    .addOption(new Option("-o, --output <output>", "The output format").choices(["json", "yaml"]))
+    .action(async ({ prod, instance, output }) => {
+      const printToTerminal = !output;
+      if (printToTerminal) {
+        intro("Getting platform configuration");
+      }
 
       const env: Partial<DotEnv> = await loadEnv(false, !!prod);
       const selectedInstance = instance ? sanitizeAndValidateInstanceUrl(instance) : await instancePrompt(env, true);
@@ -33,29 +39,20 @@ export function configCommand() {
       const useCases = getUseCases(platformConfig);
       const starterkits = getStarterkits(platformConfig);
 
-      table(
-        "Templates (Starterkits)",
-        starterkits
-          .map((starterkit) => ({
-            id: starterkit.id,
-            name: starterkit.name,
-          }))
-          .sort((a, b) => a.name.localeCompare(b.name)),
-      );
-
-      table(
-        "Use cases (Smart Contract Sets)",
-        useCases
+      const platformConfigData = {
+        useCases: useCases
           .map((useCase) => ({
             id: useCase.id,
             name: useCase.name,
           }))
           .sort((a, b) => a.name.localeCompare(b.name)),
-      );
-
-      table(
-        "Providers and regions",
-        platformConfig.deploymentEngineTargets
+        starterkits: starterkits
+          .map((starterkit) => ({
+            id: starterkit.id,
+            name: starterkit.name,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+        deploymentEngineTargets: platformConfig.deploymentEngineTargets
           .filter((provider) => !provider.disabled)
           .flatMap((provider) =>
             provider.clusters
@@ -68,10 +65,25 @@ export function configCommand() {
               })),
           )
           .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.regionId.localeCompare(b.regionId)),
-      );
+        preDeployedContracts: platformConfig.preDeployedContracts.sort(),
+      };
 
-      list("Pre-deployed abis (Smart Contract Portal)", platformConfig.preDeployedContracts.sort());
+      if (printToTerminal) {
+        table("Templates (Starterkits)", platformConfigData.starterkits);
 
-      outro("Platform configuration retrieved");
+        table("Use cases (Smart Contract Sets)", platformConfigData.useCases);
+
+        table("Providers and regions", platformConfigData.deploymentEngineTargets);
+
+        list("Pre-deployed abis (Smart Contract Portal)", platformConfigData.preDeployedContracts);
+      } else if (output === "json") {
+        jsonOutput(platformConfigData);
+      } else if (output === "yaml") {
+        yamlOutput(platformConfigData);
+      }
+
+      if (printToTerminal) {
+        outro("Platform configuration retrieved");
+      }
     });
 }

--- a/sdk/cli/src/commands/platform/workspace/list.ts
+++ b/sdk/cli/src/commands/platform/workspace/list.ts
@@ -4,12 +4,13 @@ import { workspaceSpinner } from "@/spinners/workspaces.spinner";
 import { createExamples } from "@/utils/commands/create-examples";
 import { getInstanceCredentials } from "@/utils/config";
 import { getWorkspaceUrl } from "@/utils/get-platform-url";
+import { jsonOutput } from "@/utils/output/json-output";
+import { yamlOutput } from "@/utils/output/yaml-output";
 import { Command, Option } from "@commander-js/extra-typings";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { intro, outro, table } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
-import { stringify } from "yaml";
 
 export function workspacesListCommand() {
   return new Command("workspaces")
@@ -76,9 +77,9 @@ export function workspacesListCommand() {
       if (printToTerminal) {
         table("Workspaces", workspacesData);
       } else if (output === "json") {
-        console.log(JSON.stringify(workspacesData, null, 2));
+        jsonOutput(workspacesData);
       } else if (output === "yaml") {
-        console.log(stringify(workspacesData));
+        yamlOutput(workspacesData);
       }
 
       if (printToTerminal) {

--- a/sdk/cli/src/utils/output/json-output.ts
+++ b/sdk/cli/src/utils/output/json-output.ts
@@ -1,0 +1,7 @@
+/**
+ * Outputs the given data in JSON format.
+ * @param data - The data to output in JSON format.
+ */
+export function jsonOutput(data: unknown) {
+  console.log(JSON.stringify(data, null, 2));
+}

--- a/sdk/cli/src/utils/output/yaml-output.ts
+++ b/sdk/cli/src/utils/output/yaml-output.ts
@@ -1,0 +1,9 @@
+import { stringify } from "yaml";
+
+/**
+ * Outputs the given data in YAML format.
+ * @param data - The data to output in YAML format.
+ */
+export function yamlOutput(data: unknown) {
+  console.log(stringify(data));
+}


### PR DESCRIPTION
## Summary by Sourcery

Add an `--output` option to the `platform config` command to output the platform configuration as JSON or YAML.

New Features:
- Output the platform configuration as JSON or YAML using the `--output` option in the `platform config` command.

Tests:
- Add tests for the `platform config` command.