### PR TITLE
fix: use util to mock modules

### DIFF
--- a/sdk/cli/src/commands/platform/config.test.ts
+++ b/sdk/cli/src/commands/platform/config.test.ts
@@ -2,29 +2,33 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { sdkCliCommand } from "@/commands";
 import { jsonOutput } from "@/utils/output/json-output";
 import { yamlOutput } from "@/utils/output/yaml-output";
+import { ModuleMocker } from "@/utils/test/module-mocker";
 import { table } from "@settlemint/sdk-utils/terminal";
+
+const moduleMocker = new ModuleMocker();
 
 const mockTable = mock(table);
 
 // Mock terminal module
-mock.module("@settlemint/sdk-utils/terminal", () => ({
+moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
   table: mockTable,
 }));
 
 const mockJsonOutput = mock(jsonOutput);
 
-mock.module("@/utils/output/json-output", () => ({
+moduleMocker.mock("@/utils/output/json-output", () => ({
   jsonOutput: mockJsonOutput,
 }));
 
 const mockYamlOutput = mock(yamlOutput);
 
-mock.module("@/utils/output/yaml-output", () => ({
+moduleMocker.mock("@/utils/output/yaml-output", () => ({
   yamlOutput: mockYamlOutput,
 }));
 
 afterAll(() => {
   mock.restore();
+  moduleMocker.clear();
 });
 
 describe("platform config command", () => {

--- a/sdk/cli/src/commands/platform/config.test.ts
+++ b/sdk/cli/src/commands/platform/config.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { sdkCliCommand } from "@/commands";
 import { jsonOutput } from "@/utils/output/json-output";
 import { yamlOutput } from "@/utils/output/yaml-output";
@@ -8,23 +8,20 @@ import { table } from "@settlemint/sdk-utils/terminal";
 const moduleMocker = new ModuleMocker();
 
 const mockTable = mock(table);
-
-// Mock terminal module
-moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
-  table: mockTable,
-}));
-
 const mockJsonOutput = mock(jsonOutput);
-
-moduleMocker.mock("@/utils/output/json-output", () => ({
-  jsonOutput: mockJsonOutput,
-}));
-
 const mockYamlOutput = mock(yamlOutput);
 
-moduleMocker.mock("@/utils/output/yaml-output", () => ({
-  yamlOutput: mockYamlOutput,
-}));
+beforeAll(async () => {
+  await moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
+    table: mockTable,
+  }));
+  await moduleMocker.mock("@/utils/output/yaml-output", () => ({
+    yamlOutput: mockYamlOutput,
+  }));
+  await moduleMocker.mock("@/utils/output/json-output", () => ({
+    jsonOutput: mockJsonOutput,
+  }));
+});
 
 afterAll(() => {
   mock.restore();

--- a/sdk/cli/src/prompts/smart-contract-set/subgraph-name.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/subgraph-name.prompt.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import { writeEnvSpinner } from "@/spinners/write-env.spinner";
 import { ModuleMocker } from "@/utils/test/module-mocker";
 import input from "@inquirer/input";
@@ -10,15 +10,16 @@ const mockInput = mock(({ default: defaultInput }: { default: string | undefined
   Promise.resolve(defaultInput ?? ""),
 );
 
-moduleMocker.mock("@inquirer/input", () => ({
-  default: mockInput,
-}));
-
-moduleMocker.mock("@/spinners/write-env.spinner", () => ({
-  writeEnvSpinner: mock(() => {
-    return Promise.resolve();
-  }),
-}));
+beforeAll(async () => {
+  await moduleMocker.mock("@inquirer/input", () => ({
+    default: mockInput,
+  }));
+  await moduleMocker.mock("@/spinners/write-env.spinner", () => ({
+    writeEnvSpinner: mock(() => {
+      return Promise.resolve();
+    }),
+  }));
+});
 
 afterAll(() => {
   mock.restore();

--- a/sdk/cli/src/prompts/smart-contract-set/subgraph-name.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/subgraph-name.prompt.test.ts
@@ -1,17 +1,20 @@
 import { afterAll, describe, expect, it, mock } from "bun:test";
 import { writeEnvSpinner } from "@/spinners/write-env.spinner";
+import { ModuleMocker } from "@/utils/test/module-mocker";
 import input from "@inquirer/input";
 import { subgraphNamePrompt } from "./subgraph-name.prompt";
+
+const moduleMocker = new ModuleMocker();
 
 const mockInput = mock(({ default: defaultInput }: { default: string | undefined }) =>
   Promise.resolve(defaultInput ?? ""),
 );
 
-mock.module("@inquirer/input", () => ({
+moduleMocker.mock("@inquirer/input", () => ({
   default: mockInput,
 }));
 
-mock.module("@/spinners/write-env.spinner", () => ({
+moduleMocker.mock("@/spinners/write-env.spinner", () => ({
   writeEnvSpinner: mock(() => {
     return Promise.resolve();
   }),
@@ -19,6 +22,7 @@ mock.module("@/spinners/write-env.spinner", () => ({
 
 afterAll(() => {
   mock.restore();
+  moduleMocker.clear();
 });
 
 describe("subgraphNamePrompt", () => {

--- a/sdk/cli/src/prompts/smart-contract-set/use-case.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/use-case.prompt.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { ModuleMocker } from "@/utils/test/module-mocker";
 import type { PlatformConfig } from "@settlemint/sdk-js";
 import { useCasePrompt } from "./use-case.prompt";
@@ -7,15 +7,11 @@ const moduleMocker = new ModuleMocker();
 
 const mockSelect = mock(({ choices }: { choices: { value: string }[] }) => Promise.resolve(choices[0]?.value ?? ""));
 
-moduleMocker.mock("@inquirer/select", () => ({
-  default: mockSelect,
-}));
-
-moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
-  cancel: mock((message: string) => {
-    throw new Error(message);
-  }),
-}));
+beforeAll(async () => {
+  await moduleMocker.mock("@inquirer/select", () => ({
+    default: mockSelect,
+  }));
+});
 
 afterAll(() => {
   mock.restore();

--- a/sdk/cli/src/prompts/smart-contract-set/use-case.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/use-case.prompt.test.ts
@@ -1,14 +1,17 @@
 import { afterAll, describe, expect, mock, test } from "bun:test";
+import { ModuleMocker } from "@/utils/test/module-mocker";
 import type { PlatformConfig } from "@settlemint/sdk-js";
 import { useCasePrompt } from "./use-case.prompt";
 
+const moduleMocker = new ModuleMocker();
+
 const mockSelect = mock(({ choices }: { choices: { value: string }[] }) => Promise.resolve(choices[0]?.value ?? ""));
 
-mock.module("@inquirer/select", () => ({
+moduleMocker.mock("@inquirer/select", () => ({
   default: mockSelect,
 }));
 
-mock.module("@settlemint/sdk-utils/terminal", () => ({
+moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
   cancel: mock((message: string) => {
     throw new Error(message);
   }),
@@ -16,6 +19,7 @@ mock.module("@settlemint/sdk-utils/terminal", () => ({
 
 afterAll(() => {
   mock.restore();
+  moduleMocker.clear();
 });
 
 describe("useCasePrompt", () => {

--- a/sdk/cli/src/utils/telemetry.test.ts
+++ b/sdk/cli/src/utils/telemetry.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { ModuleMocker } from "@/utils/test/module-mocker";
 import { sdkCliCommand } from "../commands";
+
+const moduleMocker = new ModuleMocker();
 
 const mockTelemetry = mock((data: unknown) => {
   console.log("telemetry", data);
@@ -7,7 +10,7 @@ const mockTelemetry = mock((data: unknown) => {
 });
 
 // Mock telemetry module
-mock.module("@/utils/telemetry", () => ({
+moduleMocker.mock("@/utils/telemetry", () => ({
   telemetry: mockTelemetry,
 }));
 
@@ -24,6 +27,7 @@ beforeAll(() => {
 afterAll(() => {
   process.exit = originalProcessExit;
   mock.restore();
+  moduleMocker.clear();
 });
 
 describe("CLI Telemetry", () => {

--- a/sdk/cli/src/utils/telemetry.test.ts
+++ b/sdk/cli/src/utils/telemetry.test.ts
@@ -9,18 +9,16 @@ const mockTelemetry = mock((data: unknown) => {
   return Promise.resolve();
 });
 
-// Mock telemetry module
-moduleMocker.mock("@/utils/telemetry", () => ({
-  telemetry: mockTelemetry,
-}));
-
 const originalProcessExit = process.exit;
 const exitMock = mock((exitCode: number) => {
   console.log("exit", exitCode);
   return Promise.resolve() as never;
 });
 
-beforeAll(() => {
+beforeAll(async () => {
+  await moduleMocker.mock("@/utils/telemetry", () => ({
+    telemetry: mockTelemetry,
+  }));
   process.exit = exitMock;
 });
 

--- a/sdk/cli/src/utils/test/module-mocker.ts
+++ b/sdk/cli/src/utils/test/module-mocker.ts
@@ -1,0 +1,58 @@
+import { mock } from "bun:test";
+
+type MockResult = {
+  clear: () => void;
+};
+
+/**
+ * Due to an issue with Bun (https://github.com/oven-sh/bun/issues/7823), we need to manually restore mocked modules
+ * after we're done. We do this by setting the mocked value to the original module.
+ *
+ * When setting up a test that will mock a module, the block should add this:
+ * const moduleMocker = new ModuleMocker()
+ *
+ * afterEach(() => {
+ *   moduleMocker.clear()
+ * })
+ *
+ * When a test mocks a module, it should do it this way:
+ *
+ * await moduleMocker.mock('@/services/token.ts', () => ({
+ *   getBucketToken: mock(() => {
+ *     throw new Error('Unexpected error')
+ *   })
+ * }))
+ * @internal
+ */
+export class ModuleMocker {
+  private mocks: MockResult[] = [];
+
+  public async mock(modulePath: string, renderMocks: () => Record<string, unknown>) {
+    try {
+      const original = {
+        ...(await import(modulePath)),
+      };
+      const mocks = renderMocks();
+      const result = {
+        ...original,
+        ...mocks,
+      };
+      mock.module(modulePath, () => result);
+
+      this.mocks.push({
+        clear: () => {
+          mock.module(modulePath, () => original);
+        },
+      });
+    } catch (error) {
+      console.error(`Error mocking module ${modulePath}:`, error);
+    }
+  }
+
+  public clear() {
+    for (const mockResult of this.mocks) {
+      mockResult.clear();
+    }
+    this.mocks = [];
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Use `ModuleMocker` to mock modules in tests.