### PR TITLE
feat: add default sender option to remote deployment

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
@@ -98,7 +98,10 @@ export function hardhatDeployRemoteCommand() {
         );
       }
 
-      const address = await addressPrompt({ env, accept: autoAccept, prod, node, hardhatConfig });
+      let address: string | null = defaultSender ?? null;
+      if (!defaultSender) {
+        address = await addressPrompt({ env, accept: autoAccept, prod, node, hardhatConfig });
+      }
       if (!address) {
         return nothingSelectedError("private key");
       }
@@ -114,11 +117,12 @@ export function hardhatDeployRemoteCommand() {
           ...(reset ? ["--reset"] : []),
           ...(verify ? ["--verify"] : []),
           ...(deploymentId ? ["--deployment-id", deploymentId] : []),
-          ...(defaultSender ? ["--default-sender", defaultSender] : []),
           ...(parameters ? ["--parameters", parameters] : []),
           ...(strategy ? ["--strategy", strategy] : []),
           "--network",
           "btp",
+          "--default-sender",
+          address,
           module ?? "ignition/modules/main.ts",
         ].filter(Boolean),
         { env: envConfig },

--- a/sdk/utils/src/terminal/execute-command.ts
+++ b/sdk/utils/src/terminal/execute-command.ts
@@ -33,6 +33,9 @@ export async function executeCommand(
   args: string[],
   options?: ExecuteCommandOptions,
 ): Promise<string[]> {
+  console.log("command", command);
+  console.log("args", args);
+  console.log("options", options);
   const child = spawn(command, args, { env: { ...process.env, ...options?.env } });
   process.stdin.pipe(child.stdin);
   const output: string[] = [];


### PR DESCRIPTION
The changes in this commit add a new `--default-sender` option to the remote deployment command in the Hardhat deployment script. This allows users to specify a default sender address for the deployment, which can be useful in scenarios where the deployment is being executed in a non-interactive environment or where the user does not want to be prompted for the sender address.

Additionally, the commit includes a change to the address prompt logic, where the script will first check if a default sender is provided, and if not, it will prompt the user for the address. This ensures that the deployment can still be executed even if a default sender is not provided.

## Summary by Sourcery

New Features:
- Added a `--default-sender` option to the `hardhat deploy remote` command, allowing users to specify a default sender address, which simplifies deployments in non-interactive environments.