### PR TITLE
fix: ignore command exit error

### DIFF
--- a/sdk/cli/src/commands/index.ts
+++ b/sdk/cli/src/commands/index.ts
@@ -1,5 +1,5 @@
 import { telemetry } from "@/utils/telemetry";
-import { Command } from "@commander-js/extra-typings";
+import { Command, CommanderError } from "@commander-js/extra-typings";
 import { AbortPromptError, CancelPromptError, ExitPromptError, ValidationError } from "@inquirer/core";
 import { CancelError, SpinnerError, ascii, maskTokens, note } from "@settlemint/sdk-utils/terminal";
 import { redBright } from "yoctocolors";
@@ -88,6 +88,10 @@ function addHooksToCommand(cmd: Command, rootCmd: ExtendedCommand, argv: string[
 async function onError(sdkcli: ExtendedCommand, argv: string[], error: Error) {
   const errorsToIgnore = [ExitPromptError, AbortPromptError, ValidationError, CancelPromptError];
   if (errorsToIgnore.some((errorToIgnore) => error instanceof errorToIgnore)) {
+    return;
+  }
+
+  if (error instanceof CommanderError && (error.exitCode === 0 || error.code === "commander.help")) {
     return;
   }
 

--- a/sdk/cli/src/commands/index.ts
+++ b/sdk/cli/src/commands/index.ts
@@ -88,11 +88,11 @@ function addHooksToCommand(cmd: Command, rootCmd: ExtendedCommand, argv: string[
 async function onError(sdkcli: ExtendedCommand, argv: string[], error: Error) {
   const errorsToIgnore = [ExitPromptError, AbortPromptError, ValidationError, CancelPromptError];
   if (errorsToIgnore.some((errorToIgnore) => error instanceof errorToIgnore)) {
-    return;
+    process.exit(0);
   }
 
   if (error instanceof CommanderError && (error.exitCode === 0 || error.code === "commander.help")) {
-    return;
+    process.exit(error.exitCode);
   }
 
   if (!(error instanceof CancelError || error instanceof SpinnerError)) {

--- a/sdk/utils/src/terminal/spinner.ts
+++ b/sdk/utils/src/terminal/spinner.ts
@@ -60,6 +60,9 @@ export const spinner = async <R>(options: SpinnerOptions<R>): Promise<R> => {
   try {
     const result = await options.task(spinner);
     spinner.success(options.stopMessage);
+    // Make sure the spinner success message is displayed before continuing
+    // In some cases the success message overlapped with next messages in the terminal
+    await new Promise((resolve) => process.nextTick(resolve));
     return result;
   } catch (err) {
     spinner.error(redBright(`${options.startMessage} --> Error!`));

--- a/sdk/utils/src/terminal/spinner.ts
+++ b/sdk/utils/src/terminal/spinner.ts
@@ -60,8 +60,8 @@ export const spinner = async <R>(options: SpinnerOptions<R>): Promise<R> => {
   try {
     const result = await options.task(spinner);
     spinner.success(options.stopMessage);
-    // Make sure the spinner success message is displayed before continuing
-    // In some cases the success message overlapped with next messages in the terminal
+    // Ensure spinner success message renders before proceeding to avoid
+    // terminal output overlap issues with subsequent messages
     await new Promise((resolve) => process.nextTick(resolve));
     return result;
   } catch (err) {


### PR DESCRIPTION
Fixes, eg closing terminal using ctrl+c will not give this error anymore

<img width="1256" alt="Screenshot 2025-01-29 at 11 25 47" src="https://github.com/user-attachments/assets/24a25bbb-9837-49a9-be4f-a70db96a8930" />
