### PR TITLE
fix: headers not applied in browser runtime

### DIFF
--- a/sdk/portal/src/portal.test.ts
+++ b/sdk/portal/src/portal.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { createPortalClient } from "./portal.js";
+
+describe("createPortalClient", () => {
+  it("should set headers correctly in server runtime", () => {
+    const { client } = createPortalClient({
+      instance: "https://portal.settlemint.com",
+      runtime: "server",
+      accessToken: "sm_aat_abc123", // Should match ApplicationAccessTokenSchema format
+    });
+
+    expect(client.requestConfig.headers).toEqual({
+      "x-auth-token": "sm_aat_abc123",
+    });
+  });
+
+  it("should set headers correctly in browser runtime", () => {
+    const { client } = createPortalClient({
+      instance: "https://portal.settlemint.com",
+      runtime: "browser",
+      accessToken: "sm_aat_abc123", // Should match ApplicationAccessTokenSchema format
+    });
+
+    expect(client.requestConfig.headers).toEqual({
+      "x-auth-token": "sm_aat_abc123",
+    });
+  });
+});

--- a/sdk/portal/src/portal.ts
+++ b/sdk/portal/src/portal.ts
@@ -42,6 +42,23 @@ function getFullUrl(options: ClientOptions): string {
 }
 
 /**
+ * Gets the headers configuration based on runtime options
+ *
+ * @param options - The validated client options
+ * @returns Headers configuration object or empty object
+ */
+function getHeaders(options: ClientOptions): Record<string, unknown> {
+  if (options.runtime === "server") {
+    return {
+      headers: {
+        "x-auth-token": options.accessToken,
+      },
+    };
+  }
+  return {};
+}
+
+/**
  * Creates a Portal GraphQL client with the provided configuration.
  *
  * @param options - Configuration options for the Portal client
@@ -115,11 +132,7 @@ export function createPortalClient<const Setup extends AbstractSetupSchema>(
   return {
     client: new GraphQLClient(fullUrl, {
       ...clientOptions,
-      ...(validatedOptions.runtime === "server" && {
-        headers: {
-          "x-auth-token": validatedOptions.accessToken,
-        },
-      }),
+      ...getHeaders(validatedOptions),
     }),
     graphql,
   };


### PR DESCRIPTION
In this code snippet:

```
return {
    client: new GraphQLClient(fullUrl, {
      ...clientOptions,
      ...(validatedOptions.runtime === "server" && {
        headers: {
          "x-auth-token": validatedOptions.accessToken,
        },
      }),
    }),
    graphql,
  };
```

The `()` around `validatedOptions.runtime...` are removed in the transpiled code, causing the x-auth-token header to not be correctly set in some cases.