### PR TITLE
fix: increase timeout for contract deployment

### DIFF
--- a/sdk/js/src/defaults/blockchain-network-defaults.ts
+++ b/sdk/js/src/defaults/blockchain-network-defaults.ts
@@ -19,7 +19,7 @@ export function setNetworkDefaults(
       evmStackSize: args.evmStackSize ?? 2048,
       gasLimit: args.gasLimit ?? "9007199254740991",
       gasPrice: args.gasPrice ?? 0,
-      secondsPerBlock: args.secondsPerBlock ?? 15,
+      secondsPerBlock: args.secondsPerBlock ?? 2,
     };
   }
   return clusterServiceArgs;

--- a/test/create-new-project.e2e.test.ts
+++ b/test/create-new-project.e2e.test.ts
@@ -148,7 +148,7 @@ describe("Setup a project using the SDK", () => {
       expect(deployOutput).toInclude("successfully deployed 🚀");
       expect(deployOutput).not.toInclude("Error reading hardhat.config.ts");
     },
-    { timeout: 5 * 60_0000 },
+    { timeout: 25 * 60_000 }, // Give it 25 minutes to deploy the contracts (typically takes around 17-18 minutes)
   );
 
   test("subgraph - Update contract addresses", async () => {

--- a/test/create-new-project.e2e.test.ts
+++ b/test/create-new-project.e2e.test.ts
@@ -124,28 +124,32 @@ describe("Setup a project using the SDK", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  test("contracts - Build and Deploy smart contracts", async () => {
-    const deploymentId = "starterkit-asset-tokenization";
-    const { output: deployOutput } = await retryCommand(
-      () =>
-        runCommand(
-          COMMAND_TEST_SCOPE,
-          ["scs", "hardhat", "deploy", "remote", "--deployment-id", deploymentId, "--accept-defaults"],
-          {
-            cwd: contractsDir,
-            env: {
-              HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: "false",
+  test(
+    "contracts - Build and Deploy smart contracts",
+    async () => {
+      const deploymentId = "starterkit-asset-tokenization";
+      const { output: deployOutput } = await retryCommand(
+        () =>
+          runCommand(
+            COMMAND_TEST_SCOPE,
+            ["scs", "hardhat", "deploy", "remote", "--deployment-id", deploymentId, "--accept-defaults"],
+            {
+              cwd: contractsDir,
+              env: {
+                HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: "false",
+              },
             },
-          },
-        ).result,
-    );
-    const deploymentInfoData = await readFile(
-      join(contractsDir, "ignition", "deployments", deploymentId, "deployed_addresses.json"),
-    );
-    contractsDeploymentInfo = JSON.parse(deploymentInfoData.toString());
-    expect(deployOutput).toInclude("successfully deployed 🚀");
-    expect(deployOutput).not.toInclude("Error reading hardhat.config.ts");
-  });
+          ).result,
+      );
+      const deploymentInfoData = await readFile(
+        join(contractsDir, "ignition", "deployments", deploymentId, "deployed_addresses.json"),
+      );
+      contractsDeploymentInfo = JSON.parse(deploymentInfoData.toString());
+      expect(deployOutput).toInclude("successfully deployed 🚀");
+      expect(deployOutput).not.toInclude("Error reading hardhat.config.ts");
+    },
+    { timeout: 5 * 60_0000 },
+  );
 
   test("subgraph - Update contract addresses", async () => {
     const config = await getSubgraphYamlConfig(subgraphDir);

--- a/test/create-new-project.e2e.test.ts
+++ b/test/create-new-project.e2e.test.ts
@@ -124,32 +124,39 @@ describe("Setup a project using the SDK", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  test(
-    "contracts - Build and Deploy smart contracts",
-    async () => {
-      const deploymentId = "starterkit-asset-tokenization";
-      const { output: deployOutput } = await retryCommand(
-        () =>
-          runCommand(
-            COMMAND_TEST_SCOPE,
-            ["scs", "hardhat", "deploy", "remote", "--deployment-id", deploymentId, "--accept-defaults"],
-            {
-              cwd: contractsDir,
-              env: {
-                HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: "false",
-              },
+  test("contracts - Build and Deploy smart contracts", async () => {
+    const deploymentId = "starterkit-asset-tokenization";
+    // Only deploy the stable coin factory, otherwise it will take very long to deploy all the contracts
+    const { output: deployOutput } = await retryCommand(
+      () =>
+        runCommand(
+          COMMAND_TEST_SCOPE,
+          [
+            "scs",
+            "hardhat",
+            "deploy",
+            "remote",
+            "--deployment-id",
+            deploymentId,
+            "--module",
+            "ignition/modules/stable-coin-factory.ts",
+            "--accept-defaults",
+          ],
+          {
+            cwd: contractsDir,
+            env: {
+              HARDHAT_IGNITION_CONFIRM_DEPLOYMENT: "false",
             },
-          ).result,
-      );
-      const deploymentInfoData = await readFile(
-        join(contractsDir, "ignition", "deployments", deploymentId, "deployed_addresses.json"),
-      );
-      contractsDeploymentInfo = JSON.parse(deploymentInfoData.toString());
-      expect(deployOutput).toInclude("successfully deployed 🚀");
-      expect(deployOutput).not.toInclude("Error reading hardhat.config.ts");
-    },
-    { timeout: 25 * 60_000 }, // Give it 25 minutes to deploy the contracts (typically takes around 17-18 minutes)
-  );
+          },
+        ).result,
+    );
+    const deploymentInfoData = await readFile(
+      join(contractsDir, "ignition", "deployments", deploymentId, "deployed_addresses.json"),
+    );
+    contractsDeploymentInfo = JSON.parse(deploymentInfoData.toString());
+    expect(deployOutput).toInclude("successfully deployed 🚀");
+    expect(deployOutput).not.toInclude("Error reading hardhat.config.ts");
+  });
 
   test("subgraph - Update contract addresses", async () => {
     const config = await getSubgraphYamlConfig(subgraphDir);

--- a/test/scripts/setup-platform-resources.ts
+++ b/test/scripts/setup-platform-resources.ts
@@ -354,6 +354,8 @@ async function createPrivateKeySmartcontractSetPortalAndBlockscoutAndNode() {
             "EquityFactory",
             "StableCoin",
             "StableCoinFactory",
+            "FundFactory",
+            "Fund",
           ]).result,
     () =>
       hasBlockscoutInsights


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Reduce the number of contracts deployed during integration tests to speed up the tests.