### PR TITLE
fix: pass through of '-v' option on commands like forge test

### DIFF
--- a/sdk/cli/src/commands/index.ts
+++ b/sdk/cli/src/commands/index.ts
@@ -132,7 +132,8 @@ export function registerCommands() {
     .helpOption("-h, --help", "Display help for command")
     .allowUnknownOption()
     .showSuggestionAfterError(true)
-    .showHelpAfterError();
+    .showHelpAfterError()
+    .passThroughOptions();
 
   // Add commands to the CLI
   sdkcli.addCommand(connectCommand());

--- a/sdk/cli/src/commands/smart-contract-set/foundry/test.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/test.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { mapPassthroughOptions } from "@/utils/commands/passthrough-options";
+import { Command } from "@commander-js/extra-typings";
+import { foundryTestCommand } from "./test";
+
+describe("foundryTestCommand", () => {
+  test("executes test command with vvv option", () => {
+    let commandOptions: string[] = [];
+    const program = new Command();
+    program.addCommand(
+      foundryTestCommand().action((passThroughOptions, cmd) => {
+        const forgeOptions = mapPassthroughOptions(passThroughOptions, cmd);
+        commandOptions = forgeOptions;
+      }),
+    );
+    program.parse(["node", "test", "test", "-vvv"]);
+
+    expect(commandOptions).toEqual(["-vvv"]);
+  });
+});


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Added a test to verify the "-v" option passthrough.