### PR TITLE
fix: disable shouldCheckForColocatedFragments

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-tsconfig.ts
+++ b/sdk/cli/src/commands/codegen/codegen-tsconfig.ts
@@ -72,6 +72,7 @@ export async function codegenTsconfig(env: DotEnv, thegraphSubgraphNames?: strin
   const tadaConfig = {
     name: "gql.tada/ts-plugin",
     trackFieldUsage: false,
+    shouldCheckForColocatedFragments: false,
     schemas: [
       ...(hasura
         ? [


### PR DESCRIPTION
Disables LSP warnings in the starterkit, see https://gql-tada.0no.co/guides/fragment-colocation#import-diagnostic