### PR TITLE
feat: add deployment id option to deploy local

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/local.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/local.ts
@@ -31,9 +31,10 @@ export function hardhatDeployLocalCommand() {
       "-m, --module <ignitionmodule>",
       'The module to deploy with Ignition, defaults to "ignition/modules/main.ts"',
     )
+    .option("--deployment-id <deploymentId>", "Set the id of the deployment")
     .option("-r, --reset", "Wipes the existing deployment state before deploying")
     .option("-v, --verify", "Verify the deployment on Etherscan")
-    .action(async ({ module, reset, verify }) => {
+    .action(async ({ module, reset, verify, deploymentId }) => {
       intro("Deploying smart contracts to local network using Hardhat/Ignition");
       await validateIfRequiredPackagesAreInstalled(["hardhat"]);
 
@@ -47,6 +48,7 @@ export function hardhatDeployLocalCommand() {
           "deploy",
           ...(reset ? ["--reset"] : []),
           ...(verify ? ["--verify"] : []),
+          ...(deploymentId ? ["--deployment-id", deploymentId] : []),
           "--network",
           "localhost",
           module ?? "ignition/modules/main.ts",

--- a/test/create-smart-contract-set.e2e.test.ts
+++ b/test/create-smart-contract-set.e2e.test.ts
@@ -132,7 +132,7 @@ describe("Setup a smart contract set using the SDK", () => {
 
       const { output: outputReset } = await runCommand(
         COMMAND_TEST_SCOPE,
-        ["scs", "hardhat", "deploy", "local", "--reset"],
+        ["scs", "hardhat", "deploy", "local", "--reset", "--deployment-id", "test"],
         {
           cwd: projectDir,
         },

--- a/test/create-smart-contract-set.e2e.test.ts
+++ b/test/create-smart-contract-set.e2e.test.ts
@@ -132,7 +132,7 @@ describe("Setup a smart contract set using the SDK", () => {
 
       const { output: outputReset } = await runCommand(
         COMMAND_TEST_SCOPE,
-        ["scs", "hardhat", "deploy", "local", "--reset", "--deployment-id", "test"],
+        ["scs", "hardhat", "deploy", "local", "--reset", "--deployment-id", "test-local"],
         {
           cwd: projectDir,
         },


### PR DESCRIPTION
## Summary by Sourcery

Add `--deployment-id` option to the `deploy local` subcommand of the CLI. Update the integration tests to use the new option.

New Features:
- Add a `--deployment-id` option to the `hardhat deploy local` command to set the deployment ID

Tests:
- Update integration tests to use the new `--deployment-id` option when running `deploy local` with `--reset`.