### PR TITLE
feat: update custom scalars

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-blockscout.ts
+++ b/sdk/cli/src/commands/codegen/codegen-blockscout.ts
@@ -165,13 +165,22 @@ export const { client: blockscoutClient, graphql: blockscoutGraphql } = createBl
   introspection: introspection;
   disableMasking: true;
   scalars: {
-    DateTime: Date;
-    JSON: Record<string, unknown>;
+    DateTime: string;
+    JSON: string;
     Bytes: string;
     Int8: string;
     BigInt: string;
     BigDecimal: string;
     Timestamp: string;
+    timestampz: string;
+    uuid: string;
+    date: string;
+    time: string;
+    jsonb: string;
+    numeric: string;
+    interval: string;
+    geometry: string;
+    geography: string;
   };
 }>({
   instance: process.env.SETTLEMINT_BLOCKSCOUT_ENDPOINT!,

--- a/sdk/cli/src/commands/codegen/codegen-hasura.ts
+++ b/sdk/cli/src/commands/codegen/codegen-hasura.ts
@@ -45,13 +45,22 @@ export const { client: hasuraClient, graphql: hasuraGraphql } = createHasuraClie
   introspection: introspection;
   disableMasking: true;
   scalars: {
-    DateTime: Date;
-    JSON: Record<string, unknown>;
+    DateTime: string;
+    JSON: string;
     Bytes: string;
     Int8: string;
     BigInt: string;
     BigDecimal: string;
     Timestamp: string;
+    timestampz: string;
+    uuid: string;
+    date: string;
+    time: string;
+    jsonb: string;
+    numeric: string;
+    interval: string;
+    geometry: string;
+    geography: string;
   };
 }>({
   instance: process.env.SETTLEMINT_HASURA_ENDPOINT ?? "",

--- a/sdk/cli/src/commands/codegen/codegen-portal.ts
+++ b/sdk/cli/src/commands/codegen/codegen-portal.ts
@@ -37,13 +37,22 @@ export const { client: portalClient, graphql: portalGraphql } = createPortalClie
   introspection: introspection;
   disableMasking: true;
   scalars: {
-    DateTime: Date;
-    JSON: Record<string, unknown>;
+    DateTime: string;
+    JSON: string;
     Bytes: string;
     Int8: string;
     BigInt: string;
     BigDecimal: string;
     Timestamp: string;
+    timestampz: string;
+    uuid: string;
+    date: string;
+    time: string;
+    jsonb: string;
+    numeric: string;
+    interval: string;
+    geometry: string;
+    geography: string;
   };
 }>({
   instance: process.env.SETTLEMINT_PORTAL_GRAPHQL_ENDPOINT!,

--- a/sdk/cli/src/commands/codegen/codegen-the-graph.ts
+++ b/sdk/cli/src/commands/codegen/codegen-the-graph.ts
@@ -63,13 +63,22 @@ export const { client: ${graphqlClientVariable}, graphql: ${graphqlVariable} } =
   introspection: ${introspectionVariable};
   disableMasking: true;
   scalars: {
-    DateTime: Date;
-    JSON: Record<string, unknown>;
+    DateTime: string;
+    JSON: string;
     Bytes: string;
     Int8: string;
     BigInt: string;
     BigDecimal: string;
     Timestamp: string;
+    timestampz: string;
+    uuid: string;
+    date: string;
+    time: string;
+    jsonb: string;
+    numeric: string;
+    interval: string;
+    geometry: string;
+    geography: string;
   };
   }>({
   instances: JSON.parse(process.env.SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS || '[]'),


### PR DESCRIPTION
## Summary by Sourcery

Updates the custom scalars used in codegen for Blockscout, Hasura, Portal, and The Graph clients. This change involves updating existing scalars to the `string` type and adding new scalars to improve type handling.

Enhancements:
- Updates custom scalars in codegen files to use `string` type instead of `Date` or `Record<string, unknown>` for `DateTime` and `JSON` scalars respectively.
- Adds new custom scalars such as `timestampz`, `uuid`, `date`, `time`, `jsonb`, `numeric`, `interval`, `geometry`, and `geography` to codegen files, all mapped to the `string` type.