### PR TITLE
fix: only select nodes with ecdsa or hsm key activated

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { type BlockchainNodePromptArgs, blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
+import { validPrivateKey } from "@/prompts/smart-contract-set/address.prompt";
+import { serviceSpinner } from "@/spinners/service.spinner";
+import { ModuleMocker } from "@/utils/test/module-mocker";
+import type { BlockchainNode, SettlemintClient } from "@settlemint/sdk-js";
+import { cancel, note } from "@settlemint/sdk-utils/terminal";
+import { selectTargetNode } from "./select-target-node";
+
+// Create mocks for all the dependencies
+const moduleMocker = new ModuleMocker();
+
+// Mock functions
+const mockBlockchainNodePrompt = mock(blockchainNodePrompt);
+const mockValidPrivateKey = mock(validPrivateKey);
+const mockServiceSpinner = mock(serviceSpinner);
+const mockNote = mock(note);
+const mockCancel = mock(cancel).mockImplementation((msg) => {
+  throw new Error(msg);
+});
+
+// Setup before and after hooks
+beforeAll(async () => {
+  await moduleMocker.mock("@/prompts/cluster-service/blockchain-node.prompt", () => ({
+    blockchainNodePrompt: mockBlockchainNodePrompt,
+  }));
+  await moduleMocker.mock("@/prompts/smart-contract-set/address.prompt", () => ({
+    validPrivateKey: mockValidPrivateKey,
+  }));
+  await moduleMocker.mock("@/spinners/service.spinner", () => ({
+    serviceSpinner: mockServiceSpinner,
+  }));
+  await moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
+    note: mockNote,
+    cancel: mockCancel,
+  }));
+});
+
+afterAll(() => {
+  mock.restore();
+  moduleMocker.clear();
+});
+
+describe("selectTargetNode", () => {
+  // Mock blockchain node data
+  const validEvmNode = {
+    id: "node-1",
+    uniqueName: "test-evm-node",
+    name: "Test EVM Node",
+    isEvm: true,
+    status: "COMPLETED",
+    privateKeys: [{ privateKeyType: "ACCESSIBLE_ECDSA_P256", address: "0x123" }],
+  } as Partial<BlockchainNode>;
+
+  const invalidEvmNode = {
+    id: "node-2",
+    uniqueName: "invalid-evm-node",
+    name: "Invalid EVM Node",
+    isEvm: false,
+    status: "COMPLETED",
+  } as Partial<BlockchainNode>;
+
+  const noPrivateKeyNode = {
+    id: "node-3",
+    uniqueName: "no-privatekey-node",
+    name: "No PrivateKey Node",
+    isEvm: true,
+    status: "COMPLETED",
+    privateKeys: [],
+  } as Partial<BlockchainNode>;
+
+  const notRunningNode = {
+    id: "node-4",
+    uniqueName: "not-running-node",
+    name: "Not Running Node",
+    isEvm: true,
+    status: "FAILED",
+    privateKeys: [{ privateKeyType: "ACCESSIBLE_ECDSA_P256", address: "0x789" }],
+  } as Partial<BlockchainNode>;
+
+  const hdPrivateKeyNode = {
+    id: "node-5",
+    uniqueName: "hd-privatekey-node",
+    name: "HD PrivateKey Node",
+    isEvm: true,
+    status: "COMPLETED",
+    privateKeys: [{ privateKeyType: "HD_ECDSA_P256", address: "0xabc" }],
+  } as Partial<BlockchainNode>;
+
+  // Mock SettleMint client
+  const mockSettlemint = {
+    blockchainNode: {
+      list: mock(async () => [validEvmNode, invalidEvmNode, noPrivateKeyNode, notRunningNode, hdPrivateKeyNode]),
+      read: mock(async (uniqueName: string) => {
+        switch (uniqueName) {
+          case "test-evm-node":
+            return validEvmNode;
+          case "invalid-evm-node":
+            return invalidEvmNode;
+          case "no-privatekey-node":
+            return noPrivateKeyNode;
+          case "not-running-node":
+            return notRunningNode;
+          case "hd-privatekey-node":
+            return hdPrivateKeyNode;
+          default:
+            throw new Error(`Node ${uniqueName} not found`);
+        }
+      }),
+    },
+  } as unknown as SettlemintClient;
+
+  // Reset mocks before each test
+  beforeEach(() => {
+    mockBlockchainNodePrompt.mockReset();
+    mockValidPrivateKey.mockReset();
+    mockServiceSpinner.mockReset();
+    mockNote.mockReset();
+
+    // Default implementation for validPrivateKey
+    mockValidPrivateKey.mockImplementation((privateKey) => privateKey.privateKeyType !== "HD_ECDSA_P256");
+
+    // Default implementation for serviceSpinner
+    mockServiceSpinner.mockImplementation(async (_, task) => task());
+  });
+
+  test("should validate node in env when autoAccept is true", async () => {
+    expect(
+      selectTargetNode({
+        env: { SETTLEMINT_BLOCKCHAIN_NODE: "no-privatekey-node" },
+        blockchainNodeUniqueName: undefined,
+        autoAccept: true,
+        settlemint: mockSettlemint,
+      }),
+    ).rejects.toThrow(
+      `The specified blockchain node '${noPrivateKeyNode.uniqueName}' does not have an ECDSA P256 or HSM ECDSA P256 private key activated. Please activate an ECDSA P256 or HSM ECDSA P256 private key on your node and try again.`,
+    );
+  });
+
+  test("should cancel when node is not an EVM node", async () => {
+    expect(
+      selectTargetNode({
+        env: {},
+        blockchainNodeUniqueName: "invalid-evm-node",
+        autoAccept: false,
+        settlemint: mockSettlemint,
+      }),
+    ).rejects.toThrow(
+      `The specified blockchain node '${invalidEvmNode.uniqueName}' is not an EVM blockchain node. Please specify an EVM blockchain node to continue.`,
+    );
+  });
+
+  test("should cancel when node has no private keys", async () => {
+    expect(
+      selectTargetNode({
+        env: {},
+        blockchainNodeUniqueName: "no-privatekey-node",
+        autoAccept: false,
+        settlemint: mockSettlemint,
+      }),
+    ).rejects.toThrow(
+      `The specified blockchain node '${noPrivateKeyNode.uniqueName}' does not have an ECDSA P256 or HSM ECDSA P256 private key activated. Please activate an ECDSA P256 or HSM ECDSA P256 private key on your node and try again.`,
+    );
+  });
+
+  test("should cancel when node has no ECDSA or HSM private keys", async () => {
+    expect(
+      selectTargetNode({
+        env: {},
+        blockchainNodeUniqueName: "hd-privatekey-node",
+        autoAccept: false,
+        settlemint: mockSettlemint,
+      }),
+    ).rejects.toThrow(
+      `The specified blockchain node '${hdPrivateKeyNode.uniqueName}' does not have an ECDSA P256 or HSM ECDSA P256 private key activated. Please activate an ECDSA P256 or HSM ECDSA P256 private key on your node and try again.`,
+    );
+  });
+
+  test("should filter out invalid nodes when prompting for selection", async () => {
+    mockBlockchainNodePrompt.mockImplementation(async (args: BlockchainNodePromptArgs) => {
+      // Verify that only valid nodes are passed to the prompt
+      expect(args.nodes.length).toBe(1);
+      expect(args.nodes[0].uniqueName).toBe("test-evm-node");
+      return validEvmNode as BlockchainNode;
+    });
+
+    const result = await selectTargetNode({
+      env: { SETTLEMINT_APPLICATION: "test-app" },
+      blockchainNodeUniqueName: undefined,
+      autoAccept: false,
+      settlemint: mockSettlemint,
+    });
+
+    expect(result.isEvm).toEqual(true);
+    expect(result.privateKeys?.length).toBe(1);
+    expect(result.privateKeys?.[0].privateKeyType).toEqual("ACCESSIBLE_ECDSA_P256");
+  });
+});

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.test.ts
@@ -1,10 +1,8 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { type BlockchainNodePromptArgs, blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
-import { validPrivateKey } from "@/prompts/smart-contract-set/address.prompt";
-import { serviceSpinner } from "@/spinners/service.spinner";
 import { ModuleMocker } from "@/utils/test/module-mocker";
 import type { BlockchainNode, SettlemintClient } from "@settlemint/sdk-js";
-import { cancel, note } from "@settlemint/sdk-utils/terminal";
+import { cancel } from "@settlemint/sdk-utils/terminal";
 import { selectTargetNode } from "./select-target-node";
 
 // Create mocks for all the dependencies
@@ -12,9 +10,6 @@ const moduleMocker = new ModuleMocker();
 
 // Mock functions
 const mockBlockchainNodePrompt = mock(blockchainNodePrompt);
-const mockValidPrivateKey = mock(validPrivateKey);
-const mockServiceSpinner = mock(serviceSpinner);
-const mockNote = mock(note);
 const mockCancel = mock(cancel).mockImplementation((msg) => {
   throw new Error(msg);
 });
@@ -24,14 +19,7 @@ beforeAll(async () => {
   await moduleMocker.mock("@/prompts/cluster-service/blockchain-node.prompt", () => ({
     blockchainNodePrompt: mockBlockchainNodePrompt,
   }));
-  await moduleMocker.mock("@/prompts/smart-contract-set/address.prompt", () => ({
-    validPrivateKey: mockValidPrivateKey,
-  }));
-  await moduleMocker.mock("@/spinners/service.spinner", () => ({
-    serviceSpinner: mockServiceSpinner,
-  }));
   await moduleMocker.mock("@settlemint/sdk-utils/terminal", () => ({
-    note: mockNote,
     cancel: mockCancel,
   }));
 });
@@ -109,20 +97,6 @@ describe("selectTargetNode", () => {
       }),
     },
   } as unknown as SettlemintClient;
-
-  // Reset mocks before each test
-  beforeEach(() => {
-    mockBlockchainNodePrompt.mockReset();
-    mockValidPrivateKey.mockReset();
-    mockServiceSpinner.mockReset();
-    mockNote.mockReset();
-
-    // Default implementation for validPrivateKey
-    mockValidPrivateKey.mockImplementation((privateKey) => privateKey.privateKeyType !== "HD_ECDSA_P256");
-
-    // Default implementation for serviceSpinner
-    mockServiceSpinner.mockImplementation(async (_, task) => task());
-  });
 
   test("should validate node in env when autoAccept is true", async () => {
     expect(

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -41,7 +41,7 @@ export async function selectTargetNode({
     );
     if (nodesWithActivePrivateKey.length === 0) {
       cancel(
-        "No blockchain nodes with ECDSA P256 or HSM ECDSA P256 private keys found. Please activate a ECDSA P256 or HSM ECDSA P256 private key on your node and try again.",
+        "No blockchain nodes with ECDSA P256 or HSM ECDSA P256 private keys were found. Please activate an ECDSA P256 or HSM ECDSA P256 private key on your node and try again.",
       );
     }
 

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -34,11 +34,14 @@ export async function selectTargetNode({
 
     const nodesWithPrivateKey = await Promise.all(nodes.map((node) => settlemint.blockchainNode.read(node.uniqueName)));
     const nodesWithActivePrivateKey = nodesWithPrivateKey.filter(
-      (node) => node.privateKeys && node.privateKeys.length > 0,
+      (node) =>
+        node.privateKeys &&
+        node.privateKeys.length > 0 &&
+        node.privateKeys.some((privateKey) => privateKey.privateKeyType !== "HD_ECDSA_P256"),
     );
     if (nodesWithActivePrivateKey.length === 0) {
       cancel(
-        "No EVM blockchain nodes with private keys found. Please activate a private key on your EVM blockchain node and try again.",
+        "No blockchain nodes with ECDSA P256 or HSM ECDSA P256 private keys found. Please activate a ECDSA P256 or HSM ECDSA P256 private key on your node and try again.",
       );
     }
 

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -1,7 +1,7 @@
 import type { HardhatConfig } from "@/utils/smart-contract-set/hardhat-config";
 import select from "@inquirer/select";
 import type { BlockchainNode } from "@settlemint/sdk-js";
-import { cancel, note } from "@settlemint/sdk-utils/terminal";
+import { note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
 /**
@@ -33,19 +33,13 @@ export async function addressPrompt({
   const defaultAddress = hardhatConfig.networks?.btp?.from ?? possiblePrivateKeys[0]?.address;
   const defaultPossible = accept && defaultAddress;
 
-  if (!node.privateKeys || node.privateKeys.length === 0) {
-    cancel(
-      `No ECDSA P256 or HSM ECDSA P256 private key is activated on the node '${node.uniqueName}'. Please activate a private key on this node or specify a different node.`,
-    );
-  }
-
   if (defaultPossible) {
     if (possiblePrivateKeys.some((privateKey) => privateKey.address?.toLowerCase() === defaultAddress?.toLowerCase())) {
       return defaultAddress;
     }
 
     note(
-      `Private key with address '${defaultAddress}' not activated on the node '${node.uniqueName}'.\nPlease select another key or activate this key on the node and try again.`,
+      `Private key with address '${defaultAddress}' is not activated on the node '${node.uniqueName}'.\nPlease select another key or activate this key on the node and try again.`,
       "warn",
     );
   }

--- a/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/address.prompt.ts
@@ -1,6 +1,6 @@
 import type { HardhatConfig } from "@/utils/smart-contract-set/hardhat-config";
 import select from "@inquirer/select";
-import type { BlockchainNode } from "@settlemint/sdk-js";
+import type { BlockchainNode, PrivateKey } from "@settlemint/sdk-js";
 import { note } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 
@@ -28,8 +28,7 @@ export async function addressPrompt({
   node: BlockchainNode;
   hardhatConfig: HardhatConfig;
 }): Promise<string | null> {
-  const possiblePrivateKeys =
-    node.privateKeys?.filter((privateKey) => privateKey.privateKeyType !== "HD_ECDSA_P256") ?? [];
+  const possiblePrivateKeys = node.privateKeys?.filter((privateKey) => validPrivateKey(privateKey)) ?? [];
   const defaultAddress = hardhatConfig.networks?.btp?.from ?? possiblePrivateKeys[0]?.address;
   const defaultPossible = accept && defaultAddress;
 
@@ -54,4 +53,8 @@ export async function addressPrompt({
   });
 
   return address;
+}
+
+export function validPrivateKey(privateKey: { privateKeyType: PrivateKey["privateKeyType"] }) {
+  return privateKey.privateKeyType !== "HD_ECDSA_P256";
 }


### PR DESCRIPTION
## Summary by Sourcery

Fixes an issue where the CLI would attempt to deploy smart contracts to nodes without an activated ECDSA or HSM key. It also improves error handling during smart contract deployment and provides more informative messages to the user.

Bug Fixes:
- Fixes an issue where the CLI would attempt to deploy smart contracts to nodes without an activated ECDSA or HSM key.
- Improves error handling during smart contract deployment, providing more informative messages to the user when a deployment is cancelled or unsuccessful.