### PR TITLE
feat: allow to set the next caching headers

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "bradlc.vscode-tailwindcss",
     "biomejs.biome",
     "graphql.vscode-graphql-syntax",
-    "inlang.vs-code-extension",
     "oven.bun-vscode",
     "dotenv.dotenv-vscode",
     "dbaeumer.vscode-eslint"

--- a/sdk/hasura/src/hasura.ts
+++ b/sdk/hasura/src/hasura.ts
@@ -21,9 +21,11 @@ export const ClientOptionsSchema = z.discriminatedUnion("runtime", [
     runtime: z.literal("server"),
     accessToken: ApplicationAccessTokenSchema,
     adminSecret: z.string(),
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
   z.object({
     runtime: z.literal("browser"),
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
 ]);
 

--- a/sdk/portal/src/portal.ts
+++ b/sdk/portal/src/portal.ts
@@ -18,9 +18,11 @@ export const ClientOptionsSchema = z.discriminatedUnion("runtime", [
     instance: UrlOrPathSchema,
     runtime: z.literal("server"),
     accessToken: ApplicationAccessTokenSchema,
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
   z.object({
     runtime: z.literal("browser"),
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
 ]);
 

--- a/sdk/thegraph/src/thegraph.ts
+++ b/sdk/thegraph/src/thegraph.ts
@@ -21,10 +21,12 @@ export const ClientOptionsSchema = z.discriminatedUnion("runtime", [
     runtime: z.literal("server"),
     accessToken: ApplicationAccessTokenSchema,
     subgraphName: z.string(),
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
   z.object({
     runtime: z.literal("browser"),
     subgraphName: z.string(),
+    cache: z.enum(["default", "force-cache", "no-cache", "no-store", "only-if-cached", "reload"]).optional(),
   }),
 ]);
 


### PR DESCRIPTION
## Summary by Sourcery

Allow setting cache headers for the Hasura, Portal, and TheGraph SDKs. This change introduces a new optional "cache" parameter to the client options, allowing users to specify caching behavior.