### PR TITLE
fix: subgraph prompt not showing when only one available

### DIFF
--- a/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.test.ts
@@ -243,9 +243,13 @@ describe("subgraphPrompt", () => {
   it("should always prompt for a subgraph when allowNew is true and accept is false", async () => {
     const env = {
       SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS: ["https://example.com/subgraph1"],
+      SETTLEMINT_THEGRAPH_DEFAULT_SUBGRAPH: "subgraph1",
     };
 
-    mockSelect.mockImplementationOnce(() => Promise.resolve("New subgraph"));
+    mockSelect.mockImplementationOnce(({ default: defaultValue }: { default: string }) => {
+      expect(defaultValue).toBe("subgraph1");
+      return Promise.resolve("New subgraph");
+    });
     mockSubgraphNamePrompt.mockImplementationOnce(() => Promise.resolve("My subgraph"));
 
     const result = await subgraphPrompt({

--- a/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.test.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.test.ts
@@ -239,4 +239,25 @@ describe("subgraphPrompt", () => {
     expect(mockSubgraphNamePrompt).toHaveBeenCalled();
     expect(mockSelect).not.toHaveBeenCalled();
   });
+
+  it("should always prompt for a subgraph when allowNew is true and accept is false", async () => {
+    const env = {
+      SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS: ["https://example.com/subgraph1"],
+    };
+
+    mockSelect.mockImplementationOnce(() => Promise.resolve("New subgraph"));
+    mockSubgraphNamePrompt.mockImplementationOnce(() => Promise.resolve("My subgraph"));
+
+    const result = await subgraphPrompt({
+      env,
+      message: "Select a subgraph",
+      allowNew: true,
+      accept: false,
+      isCi: false,
+    });
+
+    expect(result).toEqual(["My subgraph"]);
+    expect(mockSelect).toHaveBeenCalled();
+    expect(mockSubgraphNamePrompt).toHaveBeenCalled();
+  });
 });

--- a/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.ts
+++ b/sdk/cli/src/prompts/smart-contract-set/subgraph.prompt.ts
@@ -53,12 +53,14 @@ export async function subgraphPrompt({
     return subgraphNames.length === 1 ? subgraphNames : [];
   }
 
-  if (subgraphNames.length === 0 && !allowNew) {
-    cancel("No subgraphs found");
-  }
+  if (!allowNew) {
+    if (subgraphNames.length === 0) {
+      cancel("No subgraphs found");
+    }
 
-  if (subgraphNames.length === 1) {
-    return subgraphNames;
+    if (subgraphNames.length === 1) {
+      return subgraphNames;
+    }
   }
 
   const choices = subgraphNames.slice().sort();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the subgraph prompt was not showing when only one subgraph was available.