### PR TITLE
fix: command should fail in case deployment failed

### DIFF
--- a/sdk/cli/src/commands/platform/utils/wait-for-completion.ts
+++ b/sdk/cli/src/commands/platform/utils/wait-for-completion.ts
@@ -77,7 +77,7 @@ export async function waitForCompletion({
               } else {
                 note(`${capitalizeFirstLetter(type)} failed to ${getActionLabel(action)}`);
               }
-              return true;
+              return false;
             }
 
             if (spinner) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the command completion logic to return false when a deployment fails, which allows the calling command to detect and handle deployment failures