### PR TITLE
feat: add load balancer to mcp

### DIFF
--- a/sdk/mcp/src/mcp.ts
+++ b/sdk/mcp/src/mcp.ts
@@ -40,6 +40,10 @@ import { platformIntegrationToolCreate } from "./tools/platform/integration-tool
 import { platformIntegrationToolList } from "./tools/platform/integration-tool/list.js";
 import { platformIntegrationToolRead } from "./tools/platform/integration-tool/read.js";
 import { platformIntegrationToolRestart } from "./tools/platform/integration-tool/restart.js";
+import { platformLoadBalancerCreate } from "./tools/platform/load-balancer/create";
+import { platformLoadBalancerList } from "./tools/platform/load-balancer/list";
+import { platformLoadBalancerRead } from "./tools/platform/load-balancer/read";
+import { platformLoadBalancerRestart } from "./tools/platform/load-balancer/restart";
 import { platformMiddlewareCreate } from "./tools/platform/middleware/create.js";
 import { platformMiddlewareList } from "./tools/platform/middleware/list.js";
 import { platformMiddlewareRead } from "./tools/platform/middleware/read.js";
@@ -152,6 +156,12 @@ async function main() {
     platformBlockchainNodeRead(server, env, pat);
     platformBlockchainNodeCreate(server, env, pat);
     platformBlockchainNodeRestart(server, env, pat);
+
+    // Load Balancer tools
+    platformLoadBalancerList(server, env, pat);
+    platformLoadBalancerRead(server, env, pat);
+    platformLoadBalancerCreate(server, env, pat);
+    platformLoadBalancerRestart(server, env, pat);
 
     // Middleware tools
     platformMiddlewareList(server, env, pat);

--- a/sdk/mcp/src/resources/blockchain-concepts.ts
+++ b/sdk/mcp/src/resources/blockchain-concepts.ts
@@ -119,6 +119,7 @@ export const registerBlockchainConcepts = (server: McpServer) => {
 ### Blockchain Networks
 - **Blockchain Network**: A blockchain instance running on the SettleMint platform
 - **Blockchain Node**: Individual node in a blockchain network
+- **Load Balancer**: Distributes incoming JSON-RPC requests across multiple blockchain nodes
 - **Network Type**: Type of blockchain network (Ethereum, Fabric, etc.)
 - **Consensus Mechanism**: Method used to achieve agreement on the blockchain state
 

--- a/sdk/mcp/src/tools/platform/insights/create.ts
+++ b/sdk/mcp/src/tools/platform/insights/create.ts
@@ -52,6 +52,10 @@ export const platformInsightsCreate = (server: McpServer, env: Partial<DotEnv>, 
         ),
     },
     async (params) => {
+      if (params.blockchainNodeUniqueName && params.loadBalancerUniqueName) {
+        throw new Error("Only one of 'blockchainNodeUniqueName' and 'loadBalancerUniqueName' may be provided");
+      }
+
       const insights = await client.insights.create({
         applicationUniqueName: params.applicationUniqueName,
         name: params.name,

--- a/sdk/mcp/src/tools/platform/insights/create.ts
+++ b/sdk/mcp/src/tools/platform/insights/create.ts
@@ -40,7 +40,16 @@ export const platformInsightsCreate = (server: McpServer, env: Partial<DotEnv>, 
       insightsCategory: z
         .enum(["BLOCKCHAIN_EXPLORER", "HYPERLEDGER_EXPLORER", "OTTERSCAN_BLOCKCHAIN_EXPLORER"])
         .describe("Category of insights"),
-      blockchainNodeUniqueName: z.string().optional().describe("Unique name of the blockchain node to connect to"),
+      blockchainNodeUniqueName: z
+        .string()
+        .optional()
+        .describe("Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName)"),
+      loadBalancerUniqueName: z
+        .string()
+        .optional()
+        .describe(
+          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), prefer using a load balancer if available",
+        ),
     },
     async (params) => {
       const insights = await client.insights.create({
@@ -52,6 +61,7 @@ export const platformInsightsCreate = (server: McpServer, env: Partial<DotEnv>, 
         region: params.region,
         insightsCategory: params.insightsCategory,
         blockchainNodeUniqueName: params.blockchainNodeUniqueName,
+        loadBalancerUniqueName: params.loadBalancerUniqueName,
       });
 
       return {

--- a/sdk/mcp/src/tools/platform/load-balancer/create.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/create.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSettleMintClient } from "@settlemint/sdk-js";
+import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+
+/**
+ * Creates a tool for creating a new load balancer
+ *
+ * @param server - The MCP server instance
+ * @param env - Environment variables containing SettleMint credentials
+ * @param pat - Personal Access Token for SettleMint API
+ * @throws Error if required environment variables are not set
+ *
+ * @example
+ * import { platformLoadBalancerCreate } from "@settlemint/sdk-mcp/tools/platform/load-balancer/create";
+ *
+ * platformLoadBalancerCreate(server, env, pat);
+ */
+export const platformLoadBalancerCreate = (server: McpServer, env: Partial<DotEnv>, pat: string) => {
+  const instance = env.SETTLEMINT_INSTANCE;
+
+  if (!instance) {
+    throw new Error("SETTLEMINT_INSTANCE is not set");
+  }
+
+  const client = createSettleMintClient({
+    accessToken: pat,
+    instance: instance,
+  });
+
+  server.tool(
+    "platform-load-balancer-create",
+    {
+      applicationUniqueName: z.string().describe("Unique name of the application to create the load balancer in"),
+      name: z.string().describe("Name of the load balancer"),
+      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the load balancer (DEDICATED or SHARED)"),
+      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the load balancer"),
+      provider: z.string().describe("Provider for the load balancer"),
+      region: z.string().describe("Region for the load balancer"),
+      blockchainNetworkUniqueName: z.string().describe("Unique name of the blockchain network for the load balancer"),
+      connectedNodesUniqueNames: z
+        .array(z.string())
+        .describe("Unique names of the nodes to connect to the load balancer"),
+    },
+    async (params) => {
+      const loadBalancer = await client.loadBalancer.create({
+        applicationUniqueName: params.applicationUniqueName,
+        name: params.name,
+        type: params.type,
+        size: params.size,
+        provider: params.provider,
+        region: params.region,
+        blockchainNetworkUniqueName: params.blockchainNetworkUniqueName,
+        connectedNodesUniqueNames: params.connectedNodesUniqueNames,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            name: "Load Balancer Created",
+            description: `Created load balancer: ${params.name} in application: ${params.applicationUniqueName}`,
+            mimeType: "application/json",
+            text: JSON.stringify(loadBalancer, null, 2),
+          },
+        ],
+      };
+    },
+  );
+};

--- a/sdk/mcp/src/tools/platform/load-balancer/list.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/list.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSettleMintClient } from "@settlemint/sdk-js";
+import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+
+/**
+ * Creates a tool for listing load balancers in an application
+ *
+ * @param server - The MCP server instance
+ * @param env - Environment variables containing SettleMint credentials
+ * @param pat - Personal Access Token for SettleMint API
+ * @throws Error if required environment variables are not set
+ *
+ * @example
+ * import { platformLoadBalancerList } from "@settlemint/sdk-mcp/tools/platform/load-balancer/list";
+ *
+ * platformLoadBalancerList(server, env, pat);
+ */
+export const platformLoadBalancerList = (server: McpServer, env: Partial<DotEnv>, pat: string) => {
+  const instance = env.SETTLEMINT_INSTANCE;
+
+  if (!instance) {
+    throw new Error("SETTLEMINT_INSTANCE is not set");
+  }
+
+  const client = createSettleMintClient({
+    accessToken: pat,
+    instance: instance,
+  });
+
+  server.tool(
+    "platform-load-balancer-list",
+    {
+      applicationUniqueName: z.string().describe("Unique name of the application to list load balancers from"),
+    },
+    async (params) => {
+      const loadBalancers = await client.loadBalancer.list(params.applicationUniqueName);
+      return {
+        content: [
+          {
+            type: "text",
+            name: "Load Balancer List",
+            description: `List of load balancers in application: ${params.applicationUniqueName}`,
+            mimeType: "application/json",
+            text: JSON.stringify(loadBalancers, null, 2),
+          },
+        ],
+      };
+    },
+  );
+};

--- a/sdk/mcp/src/tools/platform/load-balancer/read.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/read.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSettleMintClient } from "@settlemint/sdk-js";
+import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+
+/**
+ * Creates a tool for reading a load balancer by ID
+ *
+ * @param server - The MCP server instance
+ * @param env - Environment variables containing SettleMint credentials
+ * @param pat - Personal Access Token for SettleMint API
+ * @throws Error if required environment variables are not set
+ *
+ * @example
+ * import { platformLoadBalancerRead } from "@settlemint/sdk-mcp/tools/platform/load-balancer/read";
+ *
+ * platformLoadBalancerRead(server, env, pat);
+ */
+export const platformLoadBalancerRead = (server: McpServer, env: Partial<DotEnv>, pat: string) => {
+  const instance = env.SETTLEMINT_INSTANCE;
+
+  if (!instance) {
+    throw new Error("SETTLEMINT_INSTANCE is not set");
+  }
+
+  const client = createSettleMintClient({
+    accessToken: pat,
+    instance: instance,
+  });
+
+  server.tool(
+    "platform-load-balancer-read",
+    {
+      loadBalancerUniqueName: z.string().describe("Unique name of the load balancer to read"),
+    },
+    async (params) => {
+      const loadBalancer = await client.loadBalancer.read(params.loadBalancerUniqueName);
+      return {
+        content: [
+          {
+            type: "text",
+            name: "Load Balancer Details",
+            description: `Details for load balancer: ${params.loadBalancerUniqueName}`,
+            mimeType: "application/json",
+            text: JSON.stringify(loadBalancer, null, 2),
+          },
+        ],
+      };
+    },
+  );
+};

--- a/sdk/mcp/src/tools/platform/load-balancer/restart.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/restart.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSettleMintClient } from "@settlemint/sdk-js";
+import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+
+/**
+ * Creates a tool for restarting a load balancer
+ *
+ * @param server - The MCP server instance
+ * @param env - Environment variables containing SettleMint credentials
+ * @param pat - Personal Access Token for SettleMint API
+ * @throws Error if required environment variables are not set
+ *
+ * @example
+ * import { platformLoadBalancerRestart } from "@settlemint/sdk-mcp/tools/platform/load-balancer/restart";
+ *
+ * platformLoadBalancerRestart(server, env, pat);
+ */
+export const platformLoadBalancerRestart = (server: McpServer, env: Partial<DotEnv>, pat: string) => {
+  const instance = env.SETTLEMINT_INSTANCE;
+
+  if (!instance) {
+    throw new Error("SETTLEMINT_INSTANCE is not set");
+  }
+
+  const client = createSettleMintClient({
+    accessToken: pat,
+    instance: instance,
+  });
+
+  server.tool(
+    "platform-load-balancer-restart",
+    {
+      loadBalancerUniqueName: z.string().describe("Unique name of the load balancer to restart"),
+    },
+    async (params) => {
+      const loadBalancer = await client.loadBalancer.restart(params.loadBalancerUniqueName);
+      return {
+        content: [
+          {
+            type: "text",
+            name: "Load Balancer Restarted",
+            description: `Restarted load balancer: ${params.loadBalancerUniqueName}`,
+            mimeType: "application/json",
+            text: JSON.stringify(loadBalancer, null, 2),
+          },
+        ],
+      };
+    },
+  );
+};

--- a/sdk/mcp/src/tools/platform/middleware/create.ts
+++ b/sdk/mcp/src/tools/platform/middleware/create.ts
@@ -44,16 +44,20 @@ export const platformMiddlewareCreate = (server: McpServer, env: Partial<DotEnv>
         .string()
         .optional()
         .describe(
-          "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName), prefered option for interface SMART_CONTRACT_PORTAL",
+          "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName), preferred option for interface SMART_CONTRACT_PORTAL",
         ),
       loadBalancerUniqueName: z
         .string()
         .optional()
         .describe(
-          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), prefered option for all other interfaces",
+          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), preferred option for all other interfaces",
         ),
     },
     async (params) => {
+      if (params.blockchainNodeUniqueName && params.loadBalancerUniqueName) {
+        throw new Error("Only one of 'blockchainNodeUniqueName' and 'loadBalancerUniqueName' may be provided");
+      }
+
       const middleware = await client.middleware.create({
         applicationUniqueName: params.applicationUniqueName,
         name: params.name,

--- a/sdk/mcp/src/tools/platform/middleware/create.ts
+++ b/sdk/mcp/src/tools/platform/middleware/create.ts
@@ -40,7 +40,18 @@ export const platformMiddlewareCreate = (server: McpServer, env: Partial<DotEnv>
       interface: z
         .enum(["ATTESTATION_INDEXER", "BESU", "FIREFLY_FABCONNECT", "GRAPH", "HA_GRAPH", "SMART_CONTRACT_PORTAL"])
         .describe("Interface type for the middleware"),
-      blockchainNodeUniqueName: z.string().optional().describe("Unique name of the blockchain node to connect to"),
+      blockchainNodeUniqueName: z
+        .string()
+        .optional()
+        .describe(
+          "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName), prefered option for interface SMART_CONTRACT_PORTAL",
+        ),
+      loadBalancerUniqueName: z
+        .string()
+        .optional()
+        .describe(
+          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), prefered option for all other interfaces",
+        ),
     },
     async (params) => {
       const middleware = await client.middleware.create({
@@ -52,6 +63,7 @@ export const platformMiddlewareCreate = (server: McpServer, env: Partial<DotEnv>
         region: params.region,
         interface: params.interface,
         blockchainNodeUniqueName: params.blockchainNodeUniqueName,
+        loadBalancerUniqueName: params.loadBalancerUniqueName,
       });
 
       return {


### PR DESCRIPTION
## Summary by Sourcery

Add support for load balancers in the MCP SDK, introducing new tools and schema modifications to enable load balancer management

New Features:
- Introduce load balancer management capabilities in the MCP SDK
- Add new tools for creating, listing, reading, and restarting load balancers
- Extend middleware and insights creation to support load balancer connections

Enhancements:
- Update blockchain concepts documentation to include load balancer definition
- Modify middleware and insights creation schemas to support load balancer unique names