### PR TITLE
feat: portal websocket client codegen

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-portal.ts
+++ b/sdk/cli/src/commands/codegen/codegen-portal.ts
@@ -30,7 +30,7 @@ export async function codegenPortal(env: DotEnv) {
     },
   });
 
-  const template = `import { createPortalClient } from "${PACKAGE_NAME}";
+  const template = `import { createPortalClient, getWebsocketClient } from "${PACKAGE_NAME}";
 import type { introspection } from "@schemas/portal-env";
 import { createLogger, requestLogger, type LogLevel } from '@settlemint/sdk-utils/logging';
 
@@ -48,7 +48,13 @@ export const { client: portalClient, graphql: portalGraphql } = createPortalClie
   accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
 }, {
   fetch: requestLogger(logger, "portal", fetch) as typeof fetch,
-});`;
+});
+
+export const getPortalWebsocketClient = getWebsocketClient({
+  portalGraphqlEndpoint: process.env.SETTLEMINT_PORTAL_GRAPHQL_ENDPOINT!,
+  accessToken: process.env.SETTLEMINT_ACCESS_TOKEN!,
+});
+`;
 
   await writeTemplate(template, "/lib/settlemint", "portal.ts");
 

--- a/sdk/portal/README.md
+++ b/sdk/portal/README.md
@@ -34,12 +34,14 @@
 - [API Reference](#api-reference)
   - [Functions](#functions)
     - [createPortalClient()](#createportalclient)
+    - [getWebsocketClient()](#getwebsocketclient)
     - [handleWalletVerificationChallenge()](#handlewalletverificationchallenge)
     - [waitForTransactionReceipt()](#waitfortransactionreceipt)
   - [Interfaces](#interfaces)
     - [HandleWalletVerificationChallengeOptions\<Setup\>](#handlewalletverificationchallengeoptionssetup)
     - [Transaction](#transaction)
     - [WaitForTransactionReceiptOptions](#waitfortransactionreceiptoptions)
+    - [WebsocketClientOptions](#websocketclientoptions)
   - [Type Aliases](#type-aliases)
     - [ClientOptions](#clientoptions)
     - [RequestConfig](#requestconfig)
@@ -443,6 +445,28 @@ const result = await portalClient.request(query);
 
 ***
 
+#### getWebsocketClient()
+
+> **getWebsocketClient**(`options`): `Client`
+
+Defined in: sdk/portal/src/utils/websocket-client.ts:23
+
+Creates a GraphQL WebSocket client for the Portal API
+
+##### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `options` | [`WebsocketClientOptions`](#websocketclientoptions) | The options for the client |
+
+##### Returns
+
+`Client`
+
+The GraphQL WebSocket client
+
+***
+
 #### handleWalletVerificationChallenge()
 
 > **handleWalletVerificationChallenge**\<`Setup`\>(`options`): `Promise`\<\{ `challengeResponse`: `string`; `verificationId?`: `string`; \}\>
@@ -500,7 +524,7 @@ const result = await handleWalletVerificationChallenge({
 
 > **waitForTransactionReceipt**(`transactionHash`, `options`): `Promise`\<[`Transaction`](#transaction)\>
 
-Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:82](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L82)
+Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:79](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L79)
 
 Waits for a blockchain transaction receipt by subscribing to transaction updates via GraphQL.
 This function polls until the transaction is confirmed or the timeout is reached.
@@ -552,7 +576,7 @@ Options for handling a wallet verification challenge
 
 #### Transaction
 
-Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:25](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L25)
+Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:26](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L26)
 
 Represents the structure of a blockchain transaction with its receipt
 
@@ -560,9 +584,25 @@ Represents the structure of a blockchain transaction with its receipt
 
 #### WaitForTransactionReceiptOptions
 
-Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:58](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L58)
+Defined in: [sdk/portal/src/utils/wait-for-transaction-receipt.ts:57](https://github.com/settlemint/sdk/blob/v2.2.3/sdk/portal/src/utils/wait-for-transaction-receipt.ts#L57)
 
 Options for waiting for a transaction receipt
+
+##### Extends
+
+- [`WebsocketClientOptions`](#websocketclientoptions)
+
+***
+
+#### WebsocketClientOptions
+
+Defined in: sdk/portal/src/utils/websocket-client.ts:10
+
+Options for the GraphQL WebSocket client
+
+##### Extended by
+
+- [`WaitForTransactionReceiptOptions`](#waitfortransactionreceiptoptions)
 
 ### Type Aliases
 

--- a/sdk/portal/src/portal.ts
+++ b/sdk/portal/src/portal.ts
@@ -98,5 +98,6 @@ export {
   type Transaction,
   type WaitForTransactionReceiptOptions,
 } from "./utils/wait-for-transaction-receipt.js";
+export { getWebsocketClient, type WebsocketClientOptions } from "./utils/websocket-client.js";
 export { readFragment } from "gql.tada";
 export type { FragmentOf, ResultOf, VariablesOf } from "gql.tada";

--- a/sdk/portal/src/utils/wait-for-transaction-receipt.ts
+++ b/sdk/portal/src/utils/wait-for-transaction-receipt.ts
@@ -1,4 +1,5 @@
-import { type FormattedExecutionResult, createClient } from "graphql-ws";
+import type { FormattedExecutionResult } from "graphql-ws";
+import { type WebsocketClientOptions, getWebsocketClient } from "./websocket-client.js";
 
 /**
  * Represents the structure of a blockchain transaction with its receipt
@@ -51,13 +52,9 @@ interface GetTransactionResponse {
  * Options for waiting for a transaction receipt
  *
  * @typedef {Object} WaitForTransactionReceiptOptions
- * @property {string} portalGraphqlEndpoint - The GraphQL endpoint URL for the Portal API
- * @property {string} accessToken - The access token for authentication with the Portal API
  * @property {number} [timeout] - Optional timeout in milliseconds before the operation fails
  */
-export interface WaitForTransactionReceiptOptions {
-  portalGraphqlEndpoint: string;
-  accessToken: string;
+export interface WaitForTransactionReceiptOptions extends WebsocketClientOptions {
   timeout?: number;
 }
 
@@ -80,9 +77,7 @@ export interface WaitForTransactionReceiptOptions {
  * });
  */
 export async function waitForTransactionReceipt(transactionHash: string, options: WaitForTransactionReceiptOptions) {
-  const wsClient = createClient({
-    url: options.portalGraphqlEndpoint.toLowerCase().replace("/graphql", `/${options.accessToken}/graphql`),
-  });
+  const wsClient = getWebsocketClient(options);
   const subscription = wsClient.iterate<GetTransactionResponse>({
     query: `subscription getTransaction($transactionHash: String!) {
         getTransaction(transactionHash: $transactionHash) {

--- a/sdk/portal/src/utils/websocket-client.ts
+++ b/sdk/portal/src/utils/websocket-client.ts
@@ -27,9 +27,20 @@ export function getWebsocketClient({ portalGraphqlEndpoint, accessToken }: Webso
   if (!accessToken) {
     throw new Error("accessToken is required");
   }
-  const graphqlEndpoint = new URL(portalGraphqlEndpoint);
-  graphqlEndpoint.protocol = graphqlEndpoint.protocol === "http:" ? "ws:" : "wss:";
+  const graphqlEndpoint = setWsProtocol(new URL(portalGraphqlEndpoint));
   return createClient({
     url: `${graphqlEndpoint.protocol}//${graphqlEndpoint.host}/${accessToken}${graphqlEndpoint.pathname}${graphqlEndpoint.search}`,
   });
+}
+
+function setWsProtocol(url: URL) {
+  if (url.protocol === "ws:" || url.protocol === "wss:") {
+    return url;
+  }
+  if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  } else {
+    url.protocol = "wss:";
+  }
+  return url;
 }

--- a/sdk/portal/src/utils/websocket-client.ts
+++ b/sdk/portal/src/utils/websocket-client.ts
@@ -1,0 +1,35 @@
+import { createClient } from "graphql-ws";
+
+/**
+ * Options for the GraphQL WebSocket client
+ *
+ * @typedef {Object} WebsocketClientOptions
+ * @property {string} portalGraphqlEndpoint - The GraphQL endpoint URL for the Portal API
+ * @property {string} accessToken - The access token for authentication with the Portal API
+ */
+export interface WebsocketClientOptions {
+  portalGraphqlEndpoint: string;
+  accessToken: string;
+}
+
+/**
+ * Creates a GraphQL WebSocket client for the Portal API
+ *
+ * @param {WebsocketClientOptions} options - The options for the client
+ * @param {string} options.portalGraphqlEndpoint - The GraphQL endpoint URL for the Portal API
+ * @param {string} options.accessToken - The access token for authentication with the Portal API
+ * @returns {Client} The GraphQL WebSocket client
+ */
+export function getWebsocketClient({ portalGraphqlEndpoint, accessToken }: WebsocketClientOptions) {
+  if (!portalGraphqlEndpoint) {
+    throw new Error("portalGraphqlEndpoint is required");
+  }
+  if (!accessToken) {
+    throw new Error("accessToken is required");
+  }
+  const graphqlEndpoint = new URL(portalGraphqlEndpoint);
+  graphqlEndpoint.protocol = graphqlEndpoint.protocol === "http:" ? "ws:" : "wss:";
+  return createClient({
+    url: `${graphqlEndpoint.protocol}//${graphqlEndpoint.host}/${accessToken}${graphqlEndpoint.pathname}${graphqlEndpoint.search}`,
+  });
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a reusable GraphQL WebSocket client for the Portal SDK, integrate it into the transaction receipt polling function, and update documentation and codegen to support it.

New Features:
- Introduce getWebsocketClient for creating authenticated GraphQL WebSocket clients
- Expose WebsocketClientOptions and getWebsocketClient in the Portal SDK exports
- Add getPortalWebsocketClient export in the CLI codegen for websocket support

Enhancements:
- Refactor waitForTransactionReceipt to use getWebsocketClient and extend its options interface

Documentation:
- Update README to document getWebsocketClient and WebsocketClientOptions