### PR TITLE
fix: passthrough for forge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,37 +17,25 @@
     "schedule:nonOfficeHours",
     "helpers:pinGitHubActionDigests"
   ],
-  "labels": [
-    "dependencies"
-  ],
+  "labels": ["dependencies"],
   "rebaseWhen": "auto",
   "customManagers": [
     {
       "customType": "regex",
       "datasourceTemplate": "npm",
       "depNameTemplate": "@biomejs/biome",
-      "managerFilePatterns": [
-        "/(^|/)biome.jsonc?$/"
-      ],
-      "matchStrings": [
-        "\"https://biomejs.dev/schemas/(?<currentValue>[^\"]+)/schema.json\""
-      ]
+      "managerFilePatterns": ["/(^|/)biome.jsonc?$/"],
+      "matchStrings": ["\"https://biomejs.dev/schemas/(?<currentValue>[^\"]+)/schema.json\""]
     }
   ],
   "packageRules": [
     {
-      "matchFileNames": [
-        "apps/**"
-      ],
+      "matchFileNames": ["apps/**"],
       "rangeStrategy": "pin"
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchDepTypes": [
-        "action"
-      ],
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true

--- a/sdk/cli/src/commands/smart-contract-set/foundry/build.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/build.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { mapPassthroughOptions } from "@/utils/commands/passthrough-options";
+import { Command } from "@commander-js/extra-typings";
+import { foundryBuildCommand } from "./build";
+
+describe("foundryBuildCommand", () => {
+  test("executes build command with --force option passed through", () => {
+    let capturedForgeOptions: string[] = [];
+
+    const program = new Command();
+    program.enablePositionalOptions();
+
+    const cmdToTest = foundryBuildCommand();
+
+    cmdToTest.action(async (operands, options, cmd) => {
+      capturedForgeOptions = mapPassthroughOptions(options, { args: operands } as Command);
+    });
+
+    program.addCommand(cmdToTest);
+    program.parse(["node", "cli.js", "build", "--force"]);
+
+    expect(capturedForgeOptions).toEqual(["--force"]);
+  });
+
+  test("mapPassthroughOptions correctly formats defined options and passthrough args", () => {
+    const mockCmdOperands = {
+      args: ["rawArg1", "--other-unknown"],
+    } as unknown as Command;
+
+    const parsedCmdOptions = {
+      "some-defined-option": "value",
+      "boolean-flag": true,
+    };
+
+    const commandOptions = mapPassthroughOptions(parsedCmdOptions, mockCmdOperands);
+
+    expect(commandOptions).toEqual(["--some-defined-option=value", "--boolean-flag", "rawArg1", "--other-unknown"]);
+  });
+});

--- a/sdk/cli/src/commands/smart-contract-set/foundry/build.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/build.ts
@@ -27,9 +27,10 @@ export function foundryBuildCommand() {
     .option("-h, --help", "Get list of possible forge options")
     .passThroughOptions()
     .allowUnknownOption(true)
-    .action(async (passThroughOptions, cmd) => {
+    .arguments("[operands...]")
+    .action(async (operands, options, cmd) => {
       intro("Building smart contracts using Foundry");
-      const forgeOptions = mapPassthroughOptions(passThroughOptions, cmd);
+      const forgeOptions = mapPassthroughOptions(options, { args: operands } as Command);
       await executeFoundryCommand("forge", ["build", ...forgeOptions]);
       outro("Smart contracts built successfully");
     });

--- a/sdk/cli/src/commands/smart-contract-set/foundry/format.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { mapPassthroughOptions } from "@/utils/commands/passthrough-options";
+import { Command } from "@commander-js/extra-typings";
+import { foundryFormatCommand } from "./format";
+
+describe("foundryFormatCommand", () => {
+  test("executes format command with --check option passed through", () => {
+    let capturedForgeOptions: string[] = [];
+
+    const program = new Command();
+    program.enablePositionalOptions();
+
+    const cmdToTest = foundryFormatCommand();
+
+    cmdToTest.action(async (operands, options, cmd) => {
+      capturedForgeOptions = mapPassthroughOptions(options, { args: operands } as Command);
+    });
+
+    program.addCommand(cmdToTest);
+    program.parse(["node", "cli.js", "format", "--check"]);
+
+    expect(capturedForgeOptions).toEqual(["--check"]);
+  });
+
+  test("mapPassthroughOptions correctly formats defined options and passthrough args", () => {
+    const mockCmdOperands = {
+      args: ["rawArg1", "--other-unknown"],
+    } as unknown as Command;
+
+    const parsedCmdOptions = {
+      "some-defined-option": "value",
+      "boolean-flag": true,
+    };
+
+    const commandOptions = mapPassthroughOptions(parsedCmdOptions, mockCmdOperands);
+
+    expect(commandOptions).toEqual(["--some-defined-option=value", "--boolean-flag", "rawArg1", "--other-unknown"]);
+  });
+});

--- a/sdk/cli/src/commands/smart-contract-set/foundry/format.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/format.ts
@@ -27,9 +27,10 @@ export function foundryFormatCommand() {
     .option("-h, --help", "Get list of possible forge options")
     .passThroughOptions()
     .allowUnknownOption(true)
-    .action(async (passThroughOptions, cmd) => {
+    .arguments("[operands...]")
+    .action(async (operands, options, cmd) => {
       intro("Formatting smart contracts using Foundry");
-      const forgeOptions = mapPassthroughOptions(passThroughOptions, cmd);
+      const forgeOptions = mapPassthroughOptions(options, { args: operands } as Command);
       await executeFoundryCommand("forge", ["fmt", ...forgeOptions]);
       outro("Smart contracts formatted successfully");
     });

--- a/sdk/cli/src/commands/smart-contract-set/foundry/network.test.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/network.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { mapPassthroughOptions } from "@/utils/commands/passthrough-options";
+import { Command } from "@commander-js/extra-typings";
+import { foundryNetworkCommand } from "./network";
+
+describe("foundryNetworkCommand", () => {
+  test("executes network command with --port 3000 option passed through", () => {
+    let capturedAnvilOptions: string[] = [];
+
+    const program = new Command();
+    program.enablePositionalOptions();
+
+    const cmdToTest = foundryNetworkCommand();
+
+    cmdToTest.action(async (operands, options, cmd) => {
+      capturedAnvilOptions = mapPassthroughOptions(options, { args: operands } as Command);
+    });
+
+    program.addCommand(cmdToTest);
+    // Note: "--port" and "3000" are separate arguments here for passthrough
+    program.parse(["node", "cli.js", "network", "--port", "3000"]);
+
+    expect(capturedAnvilOptions).toEqual(["--port", "3000"]);
+  });
+
+  test("mapPassthroughOptions correctly formats defined options and passthrough args", () => {
+    const mockCmdOperands = {
+      args: ["--host", "0.0.0.0", "rawArg1"],
+    } as unknown as Command;
+
+    const parsedCmdOptions = {
+      "some-defined-option": "value",
+      "boolean-flag": true,
+    };
+
+    const commandOptions = mapPassthroughOptions(parsedCmdOptions, mockCmdOperands);
+
+    expect(commandOptions).toEqual(["--some-defined-option=value", "--boolean-flag", "--host", "0.0.0.0", "rawArg1"]);
+  });
+});

--- a/sdk/cli/src/commands/smart-contract-set/foundry/network.ts
+++ b/sdk/cli/src/commands/smart-contract-set/foundry/network.ts
@@ -26,8 +26,9 @@ export function foundryNetworkCommand() {
     .option("-h, --help", "Get list of possible anvil options")
     .passThroughOptions()
     .allowUnknownOption(true)
-    .action(async (passThroughOptions, cmd) => {
-      const anvilOptions = mapPassthroughOptions(passThroughOptions, cmd);
+    .arguments("[operands...]")
+    .action(async (operands, options, cmd) => {
+      const anvilOptions = mapPassthroughOptions(options, { args: operands } as Command);
       await executeFoundryCommand("anvil", anvilOptions);
     });
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve passthrough argument handling for Foundry commands and add tests to validate their behavior.

Enhancements:
- Enable forwarding of custom flags and operands for Foundry build, format, and network commands by adding explicit argument definitions and updating mapPassthroughOptions usage

Tests:
- Add unit tests for Foundry build, format, and network commands to verify option and operand passthrough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new test suites for smart contract CLI commands, improving test coverage for build, format, and network command options and argument parsing.

- **Refactor**
  - Updated CLI commands for build, format, and network to better handle variadic arguments and option parsing, resulting in more consistent and predictable command-line behavior.

- **Style**
  - Improved formatting of configuration files for better readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->