### PR TITLE
fix: platform services command and ensure mocked modules are reset correctly

### DIFF
--- a/sdk/eas/src/eas.test.ts
+++ b/sdk/eas/src/eas.test.ts
@@ -1,36 +1,46 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import type { Address } from "viem";
+import { ModuleMocker } from "../../cli/src/utils/test/module-mocker.js";
 import { createEASClient } from "./eas.js";
 
-// Mock the viem client functions
-mock.module("@settlemint/sdk-viem", () => ({
-  getPublicClient: () => ({
-    chain: {
-      id: 1,
-      name: "Ethereum",
-      contracts: { ensRegistry: { address: undefined } },
-    },
-    transport: {
-      type: "http",
-      url: "http://localhost:8545",
-    },
-    request: async () => ({}),
-  }),
-  getWalletClient: () => () => ({
-    account: {
-      address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-      privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-    },
-    chain: {
-      id: 1,
-      name: "Ethereum",
-    },
-    transport: {
-      type: "http",
-      url: "http://localhost:8545",
-    },
-  }),
-}));
+const moduleMocker = new ModuleMocker();
+
+beforeAll(async () => {
+  // Mock the viem client functions
+  await moduleMocker.mock("@settlemint/sdk-viem", () => ({
+    getPublicClient: () => ({
+      chain: {
+        id: 1,
+        name: "Ethereum",
+        contracts: { ensRegistry: { address: undefined } },
+      },
+      transport: {
+        type: "http",
+        url: "http://localhost:8545",
+      },
+      request: async () => ({}),
+    }),
+    getWalletClient: () => () => ({
+      account: {
+        address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        privateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+      },
+      chain: {
+        id: 1,
+        name: "Ethereum",
+      },
+      transport: {
+        type: "http",
+        url: "http://localhost:8545",
+      },
+    }),
+  }));
+});
+
+afterAll(() => {
+  mock.restore();
+  moduleMocker.clear();
+});
 
 describe("EAS Client", () => {
   const options = {

--- a/test/login.e2e.test.ts
+++ b/test/login.e2e.test.ts
@@ -63,7 +63,7 @@ describe("Login command", () => {
     const command = runCommand(COMMAND_TEST_SCOPE, [
       "login",
       "--token-stdin",
-      process.env.SETTLEMINT_ACCESS_TOKEN_E2E_TESTS ?? "some_token",
+      process.env.SETTLEMINT_ACCESS_TOKEN_E2E_TESTS || "some_token",
     ]);
     const outputs: string[] = [];
     command.stdout.on("data", (data: Buffer) => {

--- a/test/login.e2e.test.ts
+++ b/test/login.e2e.test.ts
@@ -69,7 +69,10 @@ describe("Login command", () => {
     command.stdout.on("data", (data: Buffer) => {
       outputs.push(data.toString());
     });
+    command.stderr.on("data", (data: Buffer) => {
+      outputs.push(data.toString());
+    });
     expect(() => command.result).toThrow();
-    expect(outputs.join("\n")).toInclude("A token should be provided using STDIN, not as an argument");
+    expect(outputs.join("\n")).toInclude("error: too many arguments for 'login'. Expected 0 arguments but got 1");
   });
 });

--- a/test/platform-list-services.e2e.test.ts
+++ b/test/platform-list-services.e2e.test.ts
@@ -66,15 +66,8 @@ describe("Test platform list services command", () => {
       accessToken: process.env.SETTLEMINT_ACCESS_TOKEN_E2E_TESTS!,
       instance: env.SETTLEMINT_INSTANCE!,
     });
-    const { output } = await runCommand(COMMAND_TEST_SCOPE, [
-      "platform",
-      "list",
-      "services",
-      "--output",
-      "json",
-      ">",
-      "output.json",
-    ]).result;
+    const { output } = await runCommand(COMMAND_TEST_SCOPE, ["platform", "list", "services", "--output", "json"])
+      .result;
     const json = JSON.parse(output);
     const application = await settlemint.application.read(env.SETTLEMINT_APPLICATION!);
     expect(json.application).toEqual({
@@ -109,15 +102,8 @@ describe("Test platform list services command", () => {
   });
 
   test("List services in YAML format", async () => {
-    const { output } = await runCommand(COMMAND_TEST_SCOPE, [
-      "platform",
-      "list",
-      "services",
-      "--output",
-      "yaml",
-      ">",
-      "output.yaml",
-    ]).result;
+    const { output } = await runCommand(COMMAND_TEST_SCOPE, ["platform", "list", "services", "--output", "yaml"])
+      .result;
     const yaml = parseDocument(output);
     expect(yaml).toBeObject();
     const parsedYaml = yaml.toJSON();

--- a/test/utils/run-command.ts
+++ b/test/utils/run-command.ts
@@ -90,6 +90,7 @@ export function runCommand(
     result: p,
     stdin: proc.stdin,
     stdout: proc.stdout,
+    stderr: proc.stderr,
     kill: () => proc.pid && killProcess(proc.pid),
   };
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor tests to use a unified ModuleMocker for external dependencies with proper setup and teardown, ensure mocks are reset correctly, and simplify end-to-end service listing tests by capturing output directly rather than redirecting to files.

Bug Fixes:
- Ensure mocked modules are restored and cleared after tests to prevent state leakage.

Enhancements:
- Refactor unit tests to use ModuleMocker with beforeAll and afterAll hooks for mock setup and teardown.
- Simplify platform list services e2e tests by removing file redirection and capturing command output directly.

Chores:
- Remove unused SERVICE_TYPES import from services test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by restructuring mock setup and teardown using lifecycle hooks for better isolation and type safety.
  - Updated test imports and typing for enhanced maintainability.
  - Modified service listing tests to capture command output directly instead of redirecting to files, streamlining output validation.
  - Enhanced environment variable handling in login tests for more robust token fallback logic.
  - Extended command test utilities to expose error output streams for improved error monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->