### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1
 
+      - name: Install Node Gyp
+        run: bun install -g node-gyp
+
       - name: Install Bun dependencies
         run: bun install
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "biome.requireConfigFile": true,
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit",
-    "source.organizeImports": "never",
+    "source.organizeImports": "always",
     "source.organizeImports.biome": "explicit",
     "source.removeUnusedImports": "always"
   },

--- a/sdk/ipfs/src/helpers/client-options.schema.ts
+++ b/sdk/ipfs/src/helpers/client-options.schema.ts
@@ -2,7 +2,7 @@ import { ApplicationAccessTokenSchema, UrlSchema } from "@settlemint/sdk-utils/v
 import { z } from "zod/v4";
 
 /**
- * Schema for validating client options for the Portal client.
+ * Schema for validating client options for the IPFS client.
  */
 export const ClientOptionsSchema = z.object({
   /** The URL of the IPFS instance to connect to */
@@ -15,7 +15,7 @@ export const ClientOptionsSchema = z.object({
 export type ClientOptions = z.infer<typeof ClientOptionsSchema>;
 
 /**
- * Schema for validating server client options for the Portal client.
+ * Schema for validating server client options for the IPFS client.
  * Extends the ClientOptionsSchema with additional server-specific fields.
  */
 export const ServerClientOptionsSchema = ClientOptionsSchema.extend({

--- a/test/restart-resources.e2e.test.ts
+++ b/test/restart-resources.e2e.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { loadEnv } from "@settlemint/sdk-utils/environment";
+import { fetchWithRetry } from "@settlemint/sdk-utils/http";
 import { PORTAL_NAME } from "./constants/test-resources";
 import { forceExitAllCommands, runCommand } from "./utils/run-command";
 
@@ -22,5 +24,9 @@ describe("Restart platform resources using the SDK", () => {
       "--accept-defaults",
     ]).result;
     expect(output).toInclude(`Middleware ${PORTAL_NAME} restart initiated successfully`);
+    // Make sure it is running
+    const env = await loadEnv(false, false);
+    const response = await fetchWithRetry(env.SETTLEMINT_PORTAL_REST_ENDPOINT ?? "");
+    expect(response.status).toBe(401); // Unauthorized as we did not provide a token
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Fix e2e tests by updating schema documentation, enhancing the restart-resources test with a health check, and adding node-gyp installation to the CI workflow

Bug Fixes:
- Correct client-options.schema comments to reference the IPFS client instead of the Portal client

CI:
- Install node-gyp globally in the e2e CI workflow to support native module dependencies

Tests:
- Add a post-restart health check in the e2e test to assert an unauthorized response when no token is provided