### PR TITLE
feat: add NODE_TLS_REJECT_UNAUTHORIZED to env configuration

### DIFF
--- a/sdk/cli/src/commands/connect.ts
+++ b/sdk/cli/src/commands/connect.ts
@@ -307,6 +307,7 @@ async function connectToPlatform(
     ...getCustomDeploymentEnv(cDeployment),
     SETTLEMINT_BLOCKSCOUT: blockscout?.uniqueName,
     ...getBlockscoutEnv(blockscout),
+    NODE_TLS_REJECT_UNAUTHORIZED: "1",
   });
 }
 
@@ -498,5 +499,6 @@ async function connectToStandalone(
     SETTLEMINT_MINIO_SECRET_KEY: selectedServices.minioSecretKey?.result,
     SETTLEMINT_IPFS_API_ENDPOINT: selectedServices.ipfsApiEndpoint?.result,
     SETTLEMINT_BLOCKSCOUT_GRAPHQL_ENDPOINT: selectedServices.blockscoutGraphqlEndpoint?.result,
+    NODE_TLS_REJECT_UNAUTHORIZED: "0",
   });
 }

--- a/sdk/cli/src/spinners/write-env.spinner.ts
+++ b/sdk/cli/src/spinners/write-env.spinner.ts
@@ -73,6 +73,7 @@ export async function writeEnvSpinner(prod: boolean, env: Partial<DotEnv>): Prom
         SETTLEMINT_BLOCKSCOUT_UI_ENDPOINT: env.SETTLEMINT_BLOCKSCOUT_UI_ENDPOINT,
         SETTLEMINT_NEW_PROJECT_NAME: env.SETTLEMINT_NEW_PROJECT_NAME,
         SETTLEMINT_LOG_LEVEL: env.SETTLEMINT_LOG_LEVEL,
+        NODE_TLS_REJECT_UNAUTHORIZED: env.NODE_TLS_REJECT_UNAUTHORIZED,
       };
       await writeEnv({
         prod,

--- a/sdk/utils/src/validation/dot-env.schema.ts
+++ b/sdk/utils/src/validation/dot-env.schema.ts
@@ -98,6 +98,8 @@ export const DotEnvSchema = z.object({
   SETTLEMINT_NEW_PROJECT_NAME: z.string().optional(),
   /** The log level to use */
   SETTLEMINT_LOG_LEVEL: z.enum(["debug", "info", "warn", "error", "none"]).default("warn"),
+  /** Controls whether Node.js rejects unauthorized TLS certificates (0 = allow, 1 = reject) */
+  NODE_TLS_REJECT_UNAUTHORIZED: z.enum(["0", "1"]).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add NODE_TLS_REJECT_UNAUTHORIZED environment variable configuration
- Set to "0" for standalone mode to allow self-signed certificates
- Set to "1" for platform connections to enforce certificate validation

## Test plan
- [ ] Build passes (`bun run build`)
- [ ] Type checking passes (`bun run typecheck`)
- [ ] Connect to standalone instance with HTTPS works
- [ ] Connect to platform continues to work normally