### PR TITLE
fix: handle local instance in sanitizeInstanceUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,7 @@
     "node": ">=20"
   },
   "packageManager": "bun@1.1.43",
-  "workspaces": [
-    "sdk/*",
-    "apps/*"
-  ],
+  "workspaces": ["sdk/*", "apps/*"],
   "trustedDependencies": [
     "@biomejs/biome",
     "bufferutil",

--- a/sdk/cli/src/utils/instance-url-utils.test.ts
+++ b/sdk/cli/src/utils/instance-url-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import { sanitizeInstanceUrl } from "./instance-url-utils";
 
 describe("sanitizeInstanceUrl", () => {
@@ -20,5 +21,10 @@ describe("sanitizeInstanceUrl", () => {
   test("removes URL paths and query parameters", () => {
     expect(sanitizeInstanceUrl("https://test.settlemint.com/path?query=1")).toBe("https://test.settlemint.com");
     expect(sanitizeInstanceUrl("https://test.settlemint.com/path/ ")).toBe("https://test.settlemint.com");
+  });
+
+  test("handles special instance values", () => {
+    expect(sanitizeInstanceUrl(STANDALONE_INSTANCE)).toBe(STANDALONE_INSTANCE);
+    expect(sanitizeInstanceUrl(LOCAL_INSTANCE)).toBe(LOCAL_INSTANCE);
   });
 });

--- a/sdk/cli/src/utils/instance-url-utils.ts
+++ b/sdk/cli/src/utils/instance-url-utils.ts
@@ -1,7 +1,7 @@
-import { STANDALONE_INSTANCE, UrlSchema, validate } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE, UrlSchema, validate } from "@settlemint/sdk-utils/validation";
 
 export function sanitizeInstanceUrl(url: string) {
-  if (url === STANDALONE_INSTANCE) {
+  if (url === STANDALONE_INSTANCE || url === LOCAL_INSTANCE) {
     return url;
   }
   const instanceUrl = new URL(url);
@@ -10,7 +10,7 @@ export function sanitizeInstanceUrl(url: string) {
 
 export function sanitizeAndValidateInstanceUrl(url: string) {
   const sanitizedUrl = sanitizeInstanceUrl(url);
-  if (sanitizedUrl === STANDALONE_INSTANCE) {
+  if (sanitizedUrl === STANDALONE_INSTANCE || sanitizedUrl === LOCAL_INSTANCE) {
     return sanitizedUrl;
   }
   validate(UrlSchema, sanitizedUrl);


### PR DESCRIPTION
## Summary
- Fixed sanitizeInstanceUrl function to properly handle the LOCAL_INSTANCE constant ("local")
- Added support for --instance local flag in CLI, making it work the same as --instance standalone

## Test plan
- [x] Added unit tests for both STANDALONE_INSTANCE and LOCAL_INSTANCE handling
- [x] All existing tests pass
- [x] CI pipeline passes (lint, typecheck, tests)
- [x] Manual testing: `settlemint connect --instance local` should now work without throwing URL parsing errors