### PR TITLE
fix: handle merged PR notifications in Slack workflow

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -71,6 +71,8 @@ jobs:
           WR_PR_DRAFT: ${{ github.event.workflow_run.pull_requests[0].draft }}
           WR_PR_REVIEWERS: ${{ toJson(github.event.workflow_run.pull_requests[0].requested_reviewers) }}
           WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
           # Pull request context
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -99,9 +101,27 @@ jobs:
             fi
 
             if [[ "$WR_HAS_PRS" != "true" || -z "$WR_PR_NUMBER" ]]; then
-              echo "Debug: No PR associated with workflow run, skipping"
-              echo "skip_notification=true" >> $GITHUB_OUTPUT
-              exit 0
+              echo "Debug: No PR in workflow run data, checking commit message for PR number"
+              
+              # Try to extract PR number from commit message (format: "... (#123)")
+              PR_FROM_COMMIT=$(echo "$WR_HEAD_COMMIT_MESSAGE" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')
+              
+              if [[ -n "$PR_FROM_COMMIT" ]]; then
+                echo "Debug: Found PR #$PR_FROM_COMMIT in commit message"
+                WR_PR_NUMBER="$PR_FROM_COMMIT"
+                
+                # Extract PR title from commit message (everything before the PR number)
+                COMMIT_TITLE=$(echo "$WR_HEAD_COMMIT_MESSAGE" | head -1 | sed -E 's/ \(#[0-9]+\)$//')
+                WR_PR_TITLE="${COMMIT_TITLE:-PR #$WR_PR_NUMBER}"
+                
+                # For merged PRs, set appropriate state
+                WR_PR_STATE="closed"
+                WR_PR_MERGED="true"
+              else
+                echo "Debug: No PR found in commit message, skipping"
+                echo "skip_notification=true" >> $GITHUB_OUTPUT
+                exit 0
+              fi
             fi
 
             echo "build_result=$WR_CONCLUSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fix Slack notifications not updating after PR merge
- Extract PR number from commit message when workflow_run doesn't include PR data
- Properly set PR state as merged for accurate status display

## Test plan
- [ ] Create a PR and verify initial Slack notification
- [ ] Merge the PR and verify build status updates in Slack
- [ ] Confirm PR shows as "Merged" with correct build result