### PR TITLE
fix: support local instance in hasura track command

### DIFF
--- a/sdk/cli/src/commands/hasura/track.ts
+++ b/sdk/cli/src/commands/hasura/track.ts
@@ -12,7 +12,7 @@ import { extractBaseUrlBeforeSegment } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { appendHeaders } from "@settlemint/sdk-utils/http";
 import { intro, note, outro, spinner } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 export function hasuraTrackCommand() {
   return new Command("track")
@@ -46,7 +46,7 @@ export function hasuraTrackCommand() {
       let hasuraAdminSecret: string | undefined;
       let accessToken: string | undefined;
 
-      if (selectedInstance === STANDALONE_INSTANCE) {
+      if (selectedInstance === STANDALONE_INSTANCE || selectedInstance === LOCAL_INSTANCE) {
         hasuraGraphqlEndpoint = env.SETTLEMINT_HASURA_ENDPOINT;
         hasuraAdminSecret = env.SETTLEMINT_HASURA_ADMIN_SECRET;
       } else {

--- a/sdk/cli/src/commands/pincode-verification-response.ts
+++ b/sdk/cli/src/commands/pincode-verification-response.ts
@@ -12,7 +12,7 @@ import password from "@inquirer/password";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { cancel, intro, note, outro } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 export function pincodeVerificationResponseCommand() {
   return new Command("pincode-verification-response")
@@ -51,8 +51,8 @@ export function pincodeVerificationResponseCommand() {
             accept: true,
           });
 
-      if (selectedInstance === STANDALONE_INSTANCE) {
-        return cancel("This command does not support standalone instances");
+      if (selectedInstance === STANDALONE_INSTANCE || selectedInstance === LOCAL_INSTANCE) {
+        return cancel("This command does not support standalone or local instances");
       }
 
       const applicationUniqueName = env.SETTLEMINT_APPLICATION;


### PR DESCRIPTION
## Summary
- Fixed hasura track command to properly handle local instances
- Updated error message for pincode-verification-response to include local instances

## Context
The hasura track command was only checking for `STANDALONE_INSTANCE` but not `LOCAL_INSTANCE`, causing it to expect an application configuration when using `instance=local`. This fix ensures that local instances are treated the same as standalone instances, using environment variables for Hasura configuration instead of requiring platform connection.

## Changes
- Added `LOCAL_INSTANCE` check alongside `STANDALONE_INSTANCE` in hasura track command
- Updated pincode-verification-response error message to clarify both standalone and local instances are not supported

## Test Plan
- [ ] Run `settlemint hasura track` with `SETTLEMINT_INSTANCE=local` and verify it uses environment variables
- [ ] Run `settlemint pincode-verification-response` with local instance and verify appropriate error message
- [ ] Ensure existing platform-connected functionality still works correctly