### PR TITLE
fix: skip SDK version validation for local instances

### DIFF
--- a/sdk/cli/src/commands/codegen/codegen-blockscout.ts
+++ b/sdk/cli/src/commands/codegen/codegen-blockscout.ts
@@ -7,7 +7,7 @@ import { projectRoot } from "@settlemint/sdk-utils/filesystem";
 import { appendHeaders, graphqlFetchWithRetry } from "@settlemint/sdk-utils/http";
 import { installDependencies, isPackageInstalled } from "@settlemint/sdk-utils/package-manager";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 const PACKAGE_NAME = "@settlemint/sdk-blockscout";
 
@@ -19,7 +19,7 @@ export async function codegenBlockscout(env: DotEnv) {
 
   const instance = env.SETTLEMINT_INSTANCE;
   const accessToken =
-    instance === STANDALONE_INSTANCE
+    instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE
       ? undefined
       : await getApplicationOrPersonalAccessToken({
           env,

--- a/sdk/cli/src/commands/codegen/codegen-hasura.ts
+++ b/sdk/cli/src/commands/codegen/codegen-hasura.ts
@@ -4,7 +4,7 @@ import { generateSchema } from "@gql.tada/cli-utils";
 import { projectRoot } from "@settlemint/sdk-utils/filesystem";
 import { installDependencies, isPackageInstalled } from "@settlemint/sdk-utils/package-manager";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 const PACKAGE_NAME = "@settlemint/sdk-hasura";
 
@@ -13,7 +13,7 @@ export async function codegenHasura(env: DotEnv) {
 
   const instance = env.SETTLEMINT_INSTANCE;
   const accessToken =
-    instance === STANDALONE_INSTANCE
+    instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE
       ? undefined
       : await getApplicationOrPersonalAccessToken({
           env,

--- a/sdk/cli/src/commands/codegen/codegen-portal.ts
+++ b/sdk/cli/src/commands/codegen/codegen-portal.ts
@@ -3,7 +3,7 @@ import { getApplicationOrPersonalAccessToken } from "@/utils/get-app-or-personal
 import { generateSchema } from "@gql.tada/cli-utils";
 import { projectRoot } from "@settlemint/sdk-utils/filesystem";
 import { installDependencies, isPackageInstalled } from "@settlemint/sdk-utils/package-manager";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 const PACKAGE_NAME = "@settlemint/sdk-portal";
 export async function codegenPortal(env: DotEnv) {
@@ -14,7 +14,7 @@ export async function codegenPortal(env: DotEnv) {
 
   const instance = env.SETTLEMINT_INSTANCE;
   const accessToken =
-    instance === STANDALONE_INSTANCE
+    instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE
       ? undefined
       : await getApplicationOrPersonalAccessToken({
           env,

--- a/sdk/cli/src/commands/codegen/codegen-the-graph.ts
+++ b/sdk/cli/src/commands/codegen/codegen-the-graph.ts
@@ -7,7 +7,7 @@ import { capitalizeFirstLetter } from "@settlemint/sdk-utils";
 import { projectRoot } from "@settlemint/sdk-utils/filesystem";
 import { installDependencies, isPackageInstalled } from "@settlemint/sdk-utils/package-manager";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 
 const PACKAGE_NAME = "@settlemint/sdk-thegraph";
 
@@ -19,7 +19,7 @@ export async function codegenTheGraph(env: DotEnv, subgraphNames?: string[]) {
 
   const instance = env.SETTLEMINT_INSTANCE;
   const accessToken =
-    instance === STANDALONE_INSTANCE
+    instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE
       ? undefined
       : await getApplicationOrPersonalAccessToken({
           env,

--- a/sdk/cli/src/commands/codegen/codegen-tsconfig.ts
+++ b/sdk/cli/src/commands/codegen/codegen-tsconfig.ts
@@ -3,7 +3,7 @@ import { testGqlEndpoint } from "@/commands/codegen/utils/test-gql-endpoint";
 import { getApplicationOrPersonalAccessToken } from "@/utils/get-app-or-personal-token";
 import { getSubgraphName } from "@/utils/subgraph/subgraph-name";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import { getTsconfig } from "get-tsconfig";
 
 export async function codegenTsconfig(env: DotEnv, thegraphSubgraphNames?: string[]) {
@@ -19,7 +19,7 @@ export async function codegenTsconfig(env: DotEnv, thegraphSubgraphNames?: strin
   }
 
   let accessToken: string | undefined;
-  if (env.SETTLEMINT_INSTANCE !== STANDALONE_INSTANCE) {
+  if (env.SETTLEMINT_INSTANCE !== STANDALONE_INSTANCE && env.SETTLEMINT_INSTANCE !== LOCAL_INSTANCE) {
     accessToken = await getApplicationOrPersonalAccessToken({
       env,
       instance: env.SETTLEMINT_INSTANCE,

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/deploy/remote.ts
@@ -11,7 +11,7 @@ import { type BlockchainNode, createSettleMintClient } from "@settlemint/sdk-js"
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
 import { cancel, executeCommand, intro, note, outro } from "@settlemint/sdk-utils/terminal";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
 export function hardhatDeployRemoteCommand() {
@@ -88,7 +88,7 @@ export function hardhatDeployRemoteCommand() {
         env,
         accept: true,
       });
-      if (instance === STANDALONE_INSTANCE) {
+      if (instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE) {
         envHardhatConfig.BTP_RPC_URL = env.SETTLEMINT_BLOCKCHAIN_NODE_JSON_RPC_ENDPOINT ?? "";
       } else {
         const accessToken = await getApplicationOrPersonalAccessToken({

--- a/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/script/remote.ts
@@ -8,7 +8,7 @@ import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
 import { executeCommand, intro, outro } from "@settlemint/sdk-utils/terminal";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
 export function hardhatScriptRemoteCommand() {
@@ -52,7 +52,7 @@ export function hardhatScriptRemoteCommand() {
       env,
       accept: true,
     });
-    if (instance === STANDALONE_INSTANCE) {
+    if (instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE) {
       envHardhatConfig.BTP_RPC_URL = env.SETTLEMINT_BLOCKCHAIN_NODE_JSON_RPC_ENDPOINT ?? "";
     } else {
       const accessToken = await getApplicationOrPersonalAccessToken({

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
@@ -24,7 +24,7 @@ import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
 import { executeCommand, intro, outro } from "@settlemint/sdk-utils/terminal";
 import { cancel } from "@settlemint/sdk-utils/terminal";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
 export function subgraphDeployCommand() {
@@ -63,7 +63,7 @@ export function subgraphDeployCommand() {
 
       let theGraphMiddleware: Middleware | undefined;
       let accessToken: string | undefined;
-      if (instance !== STANDALONE_INSTANCE) {
+      if (instance !== STANDALONE_INSTANCE && instance !== LOCAL_INSTANCE) {
         accessToken = await getApplicationOrPersonalAccessToken({
           env,
           instance,

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/remove.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/remove.ts
@@ -17,7 +17,7 @@ import { retryWhenFailed } from "@settlemint/sdk-utils";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
 import { cancel, executeCommand, intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
 export function subgraphRemoveCommand() {
@@ -63,7 +63,7 @@ export function subgraphRemoveCommand() {
 
       let theGraphMiddleware: Middleware | undefined;
       let accessToken: string | undefined;
-      if (instance !== STANDALONE_INSTANCE) {
+      if (instance !== STANDALONE_INSTANCE && instance !== LOCAL_INSTANCE) {
         accessToken = await getApplicationOrPersonalAccessToken({
           env,
           instance,

--- a/sdk/cli/src/prompts/instance.prompt.test.ts
+++ b/sdk/cli/src/prompts/instance.prompt.test.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { removeCredentials, storeCredentials } from "@/utils/config";
 import { ModuleMocker } from "@/utils/test/module-mocker";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import { instancePrompt } from "./instance.prompt";
 
 const TEST_INSTANCE = "https://test.settlemint.com";
@@ -83,6 +83,10 @@ describe("instancePrompt", () => {
         {
           name: "Standalone (services run independently of SettleMint platform)",
           value: STANDALONE_INSTANCE,
+        },
+        {
+          name: "Local (for local development mode)",
+          value: LOCAL_INSTANCE,
         },
       ],
       default: SECOND_INSTANCE,

--- a/sdk/cli/src/prompts/instance.prompt.ts
+++ b/sdk/cli/src/prompts/instance.prompt.ts
@@ -3,7 +3,13 @@ import { sanitizeInstanceUrl } from "@/utils/instance-url-utils";
 import input from "@inquirer/input";
 import select from "@inquirer/select";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE, UrlSchema, validate } from "@settlemint/sdk-utils/validation";
+import {
+  type DotEnv,
+  LOCAL_INSTANCE,
+  STANDALONE_INSTANCE,
+  UrlSchema,
+  validate,
+} from "@settlemint/sdk-utils/validation";
 import isInCi from "is-in-ci";
 
 /**
@@ -76,6 +82,10 @@ export async function instancePrompt({
       {
         name: "Standalone (services run independently of SettleMint platform)",
         value: STANDALONE_INSTANCE,
+      },
+      {
+        name: "Local (for local development mode)",
+        value: LOCAL_INSTANCE,
       },
     ],
     default: sanitizeInstanceUrl(knownInstances.length > 0 ? defaultPromptInstance : STANDALONE_INSTANCE),

--- a/sdk/cli/src/utils/sdk-version.ts
+++ b/sdk/cli/src/utils/sdk-version.ts
@@ -3,7 +3,7 @@ import { createSettleMintClient } from "@settlemint/sdk-js";
 import { loadEnv } from "@settlemint/sdk-utils/environment";
 import { isPackageInstalled } from "@settlemint/sdk-utils/package-manager";
 import { note } from "@settlemint/sdk-utils/terminal";
-import { STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import * as semver from "semver";
 import pkg from "../../package.json";
 import { readConfig, setLastSdkVersionCheck } from "./config";
@@ -31,7 +31,7 @@ export async function validateSdkVersionFromCommand(
 
   await setLastSdkVersionCheck(new Date(now).toJSON());
   const instance = await getInstanceFromCommand(command);
-  if (instance !== STANDALONE_INSTANCE) {
+  if (instance !== STANDALONE_INSTANCE && instance !== LOCAL_INSTANCE) {
     await validateSdkVersion(instance);
   }
 }

--- a/sdk/cli/src/utils/subgraph/setup.ts
+++ b/sdk/cli/src/utils/subgraph/setup.ts
@@ -6,7 +6,7 @@ import { type Middleware, createSettleMintClient } from "@settlemint/sdk-js";
 import { exists } from "@settlemint/sdk-utils/filesystem";
 import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
 import { executeCommand } from "@settlemint/sdk-utils/terminal";
-import { type DotEnv, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import semver from "semver";
 import { executeFoundryCommand } from "../smart-contract-set/execute-foundry-command";
 import { sanitizeName } from "./sanitize-name";
@@ -113,7 +113,7 @@ export async function getTheGraphNetwork({
   instance,
   accessToken = "",
 }: { theGraphMiddleware?: Middleware; env: Partial<DotEnv>; instance: string; accessToken?: string }) {
-  if (instance === STANDALONE_INSTANCE) {
+  if (instance === STANDALONE_INSTANCE || instance === LOCAL_INSTANCE) {
     return SETTLEMINT_NETWORK;
   }
   const isFixedNetwork = (theGraphMiddleware?.entityVersion ?? 4) >= 4;

--- a/sdk/js/src/settlemint.ts
+++ b/sdk/js/src/settlemint.ts
@@ -1,6 +1,6 @@
 import { fetchWithRetry } from "@settlemint/sdk-utils/http";
 import { ensureServer } from "@settlemint/sdk-utils/runtime";
-import { type Id, STANDALONE_INSTANCE, validate } from "@settlemint/sdk-utils/validation";
+import { type Id, LOCAL_INSTANCE, STANDALONE_INSTANCE, validate } from "@settlemint/sdk-utils/validation";
 import { GraphQLClient } from "graphql-request";
 import { z } from "zod/v4";
 import {
@@ -239,13 +239,13 @@ export interface SettlemintClient {
 export function createSettleMintClient(options: SettlemintClientOptions): SettlemintClient {
   ensureServer();
 
-  if (options.instance === STANDALONE_INSTANCE) {
+  if (options.instance === STANDALONE_INSTANCE || options.instance === LOCAL_INSTANCE) {
     if (options.anonymous) {
       // Fallback to the public instance for anonymous access
       // Anonymous use does not interact with platform services, only used for bootstrapping new projects using SettleMint templates
       options.instance = "https://console.settlemint.com";
     } else {
-      throw new Error("Standalone instances cannot connect to the SettleMint platform");
+      throw new Error("Standalone and local instances cannot connect to the SettleMint platform");
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed SDK version validation error for local instances
- Fixed inconsistent handling of `LOCAL_INSTANCE` vs `STANDALONE_INSTANCE` across the SDK  
- Added `LOCAL_INSTANCE` as a selectable option in the instance prompt
- Ensured all commands treat local mode the same as standalone mode

## Changes

### Initial Fix
- **`sdk/cli/src/utils/sdk-version.ts`**: Skip SDK version validation for both `STANDALONE_INSTANCE` and `LOCAL_INSTANCE`
- **`sdk/js/src/settlemint.ts`**: Handle `LOCAL_INSTANCE` same as `STANDALONE_INSTANCE` in client creation

### Comprehensive Fix - 12 Additional Files
After deep analysis, I identified and fixed 12 more files where `LOCAL_INSTANCE` was not handled consistently:

#### 1. **Codegen Commands** 
All codegen commands were only checking for `STANDALONE_INSTANCE` when deciding whether to get an access token:
- `codegen-the-graph.ts` 
- `codegen-portal.ts` 
- `codegen-hasura.ts`
- `codegen-blockscout.ts`
- `codegen-tsconfig.ts`

#### 2. **Instance Prompt**
- `instance.prompt.ts` - Added "Local (for local development mode)" as a selectable option

#### 3. **Subgraph Commands**
- `subgraph/deploy.ts` - Fixed to skip platform operations for local mode
- `subgraph/remove.ts` - Fixed to skip platform operations for local mode

#### 4. **Hardhat Commands**
- `hardhat/deploy/remote.ts` - Fixed to use local RPC URL for local mode
- `hardhat/script/remote.ts` - Fixed to use local RPC URL for local mode

#### 5. **Subgraph Setup Utility**
- `subgraph/setup.ts` - Fixed `getTheGraphNetwork` to return SETTLEMINT_NETWORK for local mode

## Test Plan
- [ ] Run `settlemint scs foundry build --sizes` with `--instance local`
- [ ] Run `settlemint codegen` with `SETTLEMINT_INSTANCE=local` 
- [ ] Test subgraph deploy/remove commands in local mode
- [ ] Test hardhat deploy/script commands in local mode
- [ ] Verify instance prompt shows "Local" option
- [ ] Ensure no authentication is attempted for local mode operations

Fixes the validation error: "instance: Invalid URL" when using local mode commands.