### PR TITLE
feat: print sdk version on each command

### DIFF
--- a/sdk/cli/src/commands/index.ts
+++ b/sdk/cli/src/commands/index.ts
@@ -1,10 +1,10 @@
-import { telemetry } from "@/utils/telemetry";
 import { Command, CommanderError } from "@commander-js/extra-typings";
 import { AbortPromptError, CancelPromptError, ExitPromptError, ValidationError } from "@inquirer/core";
-import { CancelError, SpinnerError, ascii, maskTokens, note } from "@settlemint/sdk-utils/terminal";
-import { redBright } from "yoctocolors";
+import { ascii, CancelError, maskTokens, note, SpinnerError } from "@settlemint/sdk-utils/terminal";
+import { magentaBright, redBright } from "yoctocolors";
+import { telemetry } from "@/utils/telemetry";
 import pkg from "../../package.json";
-import { validateSdkVersionFromCommand } from "../utils/sdk-version";
+import { getInstalledSdkVersion, validateSdkVersionFromCommand } from "../utils/sdk-version";
 import { codegenCommand } from "./codegen";
 import { connectCommand } from "./connect";
 import { createCommand } from "./create";
@@ -68,6 +68,7 @@ function addHooksToCommand(cmd: Command, rootCmd: ExtendedCommand, argv: string[
       }
       if (isLeafCommand(thisCommand)) {
         ascii();
+        note(magentaBright(`v${getInstalledSdkVersion()}`));
         await validateSdkVersionFromCommand(thisCommand);
       }
     })

--- a/sdk/cli/src/utils/sdk-version.ts
+++ b/sdk/cli/src/utils/sdk-version.ts
@@ -11,6 +11,15 @@ import { readConfig, setLastSdkVersionCheck } from "./config";
 const SDK_PACKAGE_NAME = "@settlemint/sdk-cli";
 
 /**
+ * Returns the installed SDK version
+ *
+ * @returns The installed SDK version
+ */
+export function getInstalledSdkVersion() {
+  return pkg.version;
+}
+
+/**
  * Validates the SDK version against the platform's supported version
  *
  * @param command - The command to validate the SDK version against


### PR DESCRIPTION
Makes it easier to troubleshoot issues when you get a screenshot for example

## Summary by Sourcery

New Features:
- Display the installed SDK CLI version before executing any leaf command invocation.