### PR TITLE
chore: add scripts workspace and update bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,16 @@
         "typescript": "5.8.3",
       },
     },
+    "scripts": {
+      "name": "scripts",
+      "devDependencies": {
+        "@settlemint/sdk-utils": "workspace:*",
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
     "sdk/blockscout": {
       "name": "@settlemint/sdk-blockscout",
       "version": "0.9.0",
@@ -1384,6 +1394,8 @@
     "sax": ["sax@1.4.1", "", {}, "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+
+    "scripts": ["scripts@workspace:scripts"],
 
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   },
   "workspaces": [
     "sdk/*",
-    "test"
+    "test",
+    "scripts"
   ],
   "trustedDependencies": [
     "@biomejs/biome",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "scripts",
+  "private": true,
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@settlemint/sdk-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/sdk/utils/src/filesystem/mono-repo.test.ts
+++ b/sdk/utils/src/filesystem/mono-repo.test.ts
@@ -46,6 +46,7 @@ describe("mono-repo utilities", () => {
       "minio",
       "next",
       "portal",
+      "scripts",
       "sdk",
       "test",
       "thegraph",


### PR DESCRIPTION
- Added a new workspace for "scripts" in package.json.
- Updated bun.lock to include new devDependencies and peerDependencies for the scripts workspace.
- Included "scripts" in the list of packages in the mono-repo test file.