### PR TITLE
feat: support for HAGraphPostgresMiddleware middleware

### DIFF
--- a/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
+++ b/sdk/cli/src/commands/smart-contract-set/hardhat/utils/select-target-node.ts
@@ -6,7 +6,7 @@ import { nothingSelectedError } from "@/error/nothing-selected-error";
 import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { blockchainNodePrompt } from "@/prompts/cluster-service/blockchain-node.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
-import { hasValidPrivateKey } from "@/utils/cluster-service";
+import { hasValidPrivateKey, isRunning } from "@/utils/cluster-service";
 
 export async function selectTargetNode({
   env,
@@ -78,7 +78,7 @@ function validateNode(node: BlockchainNode, cancelOnError = true) {
     }
     return false;
   }
-  if (node.status !== "COMPLETED") {
+  if (!isRunning(node)) {
     if (cancelOnError) {
       serviceNotRunningError("blockchain node", node.status);
     }

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/deploy.ts
@@ -1,10 +1,18 @@
+import { Command } from "@commander-js/extra-typings";
+import { createSettleMintClient, type Middleware } from "@settlemint/sdk-js";
+import { loadEnv } from "@settlemint/sdk-utils/environment";
+import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
+import { cancel, executeCommand, intro, outro } from "@settlemint/sdk-utils/terminal";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import isInCi from "is-in-ci";
 import { nothingSelectedError } from "@/error/nothing-selected-error";
 import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { instancePrompt } from "@/prompts/instance.prompt";
-import { subgraphNamePrompt } from "@/prompts/smart-contract-set/subgraph-name.prompt";
 import { subgraphPrompt } from "@/prompts/smart-contract-set/subgraph.prompt";
+import { subgraphNamePrompt } from "@/prompts/smart-contract-set/subgraph-name.prompt";
 import { serviceUrlPrompt } from "@/prompts/standalone/service-url.prompt";
 import { writeEnvSpinner } from "@/spinners/write-env.spinner";
+import { isRunning } from "@/utils/cluster-service";
 import { createExamples } from "@/utils/commands/create-examples";
 import { getApplicationOrPersonalAccessToken } from "@/utils/get-app-or-personal-token";
 import { getGraphEnv } from "@/utils/get-cluster-service-env";
@@ -18,14 +26,6 @@ import {
 } from "@/utils/subgraph/subgraph-config";
 import { getTheGraphUrl, getUpdatedSubgraphEndpoints } from "@/utils/subgraph/thegraph-url";
 import { validateIfRequiredPackagesAreInstalled } from "@/utils/validate-required-packages";
-import { Command } from "@commander-js/extra-typings";
-import { type Middleware, createSettleMintClient } from "@settlemint/sdk-js";
-import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
-import { executeCommand, intro, outro } from "@settlemint/sdk-utils/terminal";
-import { cancel } from "@settlemint/sdk-utils/terminal";
-import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
-import isInCi from "is-in-ci";
 
 export function subgraphDeployCommand() {
   return new Command("deploy")
@@ -74,7 +74,7 @@ export function subgraphDeployCommand() {
         if (!theGraphMiddleware) {
           return nothingSelectedError("graph middleware");
         }
-        if (theGraphMiddleware.status !== "COMPLETED") {
+        if (!isRunning(theGraphMiddleware)) {
           serviceNotRunningError("graph middleware", theGraphMiddleware.status);
         }
 

--- a/sdk/cli/src/commands/smart-contract-set/subgraph/remove.ts
+++ b/sdk/cli/src/commands/smart-contract-set/subgraph/remove.ts
@@ -1,3 +1,11 @@
+import { Command } from "@commander-js/extra-typings";
+import { createSettleMintClient, type Middleware } from "@settlemint/sdk-js";
+import { retryWhenFailed } from "@settlemint/sdk-utils";
+import { loadEnv } from "@settlemint/sdk-utils/environment";
+import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
+import { cancel, executeCommand, intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
+import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
+import isInCi from "is-in-ci";
 import { nothingSelectedError } from "@/error/nothing-selected-error";
 import { serviceNotRunningError } from "@/error/service-not-running-error";
 import { deleteConfirmationPrompt } from "@/prompts/delete-confirmation.prompt";
@@ -5,20 +13,13 @@ import { instancePrompt } from "@/prompts/instance.prompt";
 import { subgraphPrompt } from "@/prompts/smart-contract-set/subgraph.prompt";
 import { serviceUrlPrompt } from "@/prompts/standalone/service-url.prompt";
 import { writeEnvSpinner } from "@/spinners/write-env.spinner";
+import { isRunning } from "@/utils/cluster-service";
 import { createExamples } from "@/utils/commands/create-examples";
 import { getApplicationOrPersonalAccessToken } from "@/utils/get-app-or-personal-token";
 import { getGraphEnv } from "@/utils/get-cluster-service-env";
 import { getTheGraphMiddleware } from "@/utils/subgraph/setup";
 import { getTheGraphUrl, getUpdatedSubgraphEndpoints } from "@/utils/subgraph/thegraph-url";
 import { validateIfRequiredPackagesAreInstalled } from "@/utils/validate-required-packages";
-import { Command } from "@commander-js/extra-typings";
-import { type Middleware, createSettleMintClient } from "@settlemint/sdk-js";
-import { retryWhenFailed } from "@settlemint/sdk-utils";
-import { loadEnv } from "@settlemint/sdk-utils/environment";
-import { getPackageManagerExecutable } from "@settlemint/sdk-utils/package-manager";
-import { cancel, executeCommand, intro, outro, spinner } from "@settlemint/sdk-utils/terminal";
-import { LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
-import isInCi from "is-in-ci";
 
 export function subgraphRemoveCommand() {
   return new Command("remove")
@@ -74,7 +75,7 @@ export function subgraphRemoveCommand() {
         if (!theGraphMiddleware) {
           return nothingSelectedError("graph middleware");
         }
-        if (theGraphMiddleware.status !== "COMPLETED") {
+        if (!isRunning(theGraphMiddleware)) {
           serviceNotRunningError("graph middleware", theGraphMiddleware.status);
         }
       }

--- a/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
@@ -1,18 +1,18 @@
-import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
-import { isRunning } from "@/utils/cluster-service";
 import select from "@inquirer/select";
 import type { Middleware } from "@settlemint/sdk-js";
+import { type BaseServicePromptArgs, servicePrompt } from "@/prompts/cluster-service/service.prompt";
+import { isRunning } from "@/utils/cluster-service";
 
 /**
- * Extract HAGraphMiddleware type from the Middleware union type
+ * Extract HAGraphMiddleware or HAGraphPostgresMiddleware type from the Middleware union type
  */
-export type HAGraphMiddleware = Extract<Middleware, { __typename: "HAGraphMiddleware" }>;
+export type HAGraphMiddleware = Extract<Middleware, { __typename: "HAGraphMiddleware" | "HAGraphPostgresMiddleware" }>;
 
 /**
- * Type guard to check if a middleware is HAGraphMiddleware
+ * Type guard to check if a middleware is HAGraphMiddleware or HAGraphPostgresMiddleware
  */
 export function isHAGraphMiddleware(middleware: Middleware): middleware is HAGraphMiddleware {
-  return middleware.__typename === "HAGraphMiddleware";
+  return middleware.__typename === "HAGraphMiddleware" || middleware.__typename === "HAGraphPostgresMiddleware";
 }
 
 export interface TheGraphPromptArgs extends BaseServicePromptArgs {

--- a/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
+++ b/sdk/cli/src/prompts/cluster-service/thegraph.prompt.ts
@@ -6,12 +6,15 @@ import { isRunning } from "@/utils/cluster-service";
 /**
  * Extract HAGraphMiddleware or HAGraphPostgresMiddleware type from the Middleware union type
  */
-export type HAGraphMiddleware = Extract<Middleware, { __typename: "HAGraphMiddleware" | "HAGraphPostgresMiddleware" }>;
+export type AnyHAGraphMiddleware = Extract<
+  Middleware,
+  { __typename: "HAGraphMiddleware" | "HAGraphPostgresMiddleware" }
+>;
 
 /**
  * Type guard to check if a middleware is HAGraphMiddleware or HAGraphPostgresMiddleware
  */
-export function isHAGraphMiddleware(middleware: Middleware): middleware is HAGraphMiddleware {
+export function isAnyHAGraphMiddleware(middleware: Middleware): middleware is AnyHAGraphMiddleware {
   return middleware.__typename === "HAGraphMiddleware" || middleware.__typename === "HAGraphPostgresMiddleware";
 }
 
@@ -36,8 +39,8 @@ export async function theGraphPrompt({
   accept,
   filterRunningOnly = false,
   isRequired = false,
-}: TheGraphPromptArgs): Promise<HAGraphMiddleware | undefined> {
-  const graphMiddlewares = middlewares.filter(isHAGraphMiddleware);
+}: TheGraphPromptArgs): Promise<AnyHAGraphMiddleware | undefined> {
+  const graphMiddlewares = middlewares.filter(isAnyHAGraphMiddleware);
   return servicePrompt({
     env,
     services: graphMiddlewares,

--- a/sdk/cli/src/utils/get-cluster-service-env.ts
+++ b/sdk/cli/src/utils/get-cluster-service-env.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_SUBGRAPH_NAME } from "@/constants/default-subgraph";
 import type {
   BlockchainNode,
   CustomDeployment,
@@ -13,6 +12,8 @@ import type {
 import { retryWhenFailed } from "@settlemint/sdk-utils/retry";
 import { spinner } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { DEFAULT_SUBGRAPH_NAME } from "@/constants/default-subgraph";
+import { isHAGraphMiddleware } from "@/prompts/cluster-service/thegraph.prompt";
 import { getSubgraphName } from "./subgraph/subgraph-name";
 
 export async function getGraphEnv(
@@ -20,7 +21,7 @@ export async function getGraphEnv(
   service: Middleware | undefined,
   graphName?: string,
 ): Promise<Partial<DotEnv>> {
-  if (!service || service.__typename !== "HAGraphMiddleware") {
+  if (!service || !isHAGraphMiddleware(service)) {
     return {};
   }
 
@@ -30,7 +31,7 @@ export async function getGraphEnv(
     task: () =>
       retryWhenFailed(async () => {
         const middleware = await settlemint.middleware.graphSubgraphs(service.uniqueName, !!graphName);
-        if (!middleware || middleware.__typename !== "HAGraphMiddleware") {
+        if (!middleware || !isHAGraphMiddleware(middleware)) {
           throw new Error(`Middleware '${service.uniqueName}' is not a graph middleware`);
         }
         if (

--- a/sdk/cli/src/utils/get-cluster-service-env.ts
+++ b/sdk/cli/src/utils/get-cluster-service-env.ts
@@ -13,7 +13,7 @@ import { retryWhenFailed } from "@settlemint/sdk-utils/retry";
 import { spinner } from "@settlemint/sdk-utils/terminal";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { DEFAULT_SUBGRAPH_NAME } from "@/constants/default-subgraph";
-import { isHAGraphMiddleware } from "@/prompts/cluster-service/thegraph.prompt";
+import { isAnyHAGraphMiddleware } from "@/prompts/cluster-service/thegraph.prompt";
 import { getSubgraphName } from "./subgraph/subgraph-name";
 
 export async function getGraphEnv(
@@ -21,7 +21,7 @@ export async function getGraphEnv(
   service: Middleware | undefined,
   graphName?: string,
 ): Promise<Partial<DotEnv>> {
-  if (!service || !isHAGraphMiddleware(service)) {
+  if (!service || !isAnyHAGraphMiddleware(service)) {
     return {};
   }
 
@@ -31,7 +31,7 @@ export async function getGraphEnv(
     task: () =>
       retryWhenFailed(async () => {
         const middleware = await settlemint.middleware.graphSubgraphs(service.uniqueName, !!graphName);
-        if (!middleware || !isHAGraphMiddleware(middleware)) {
+        if (!middleware || !isAnyHAGraphMiddleware(middleware)) {
           throw new Error(`Middleware '${service.uniqueName}' is not a graph middleware`);
         }
         if (

--- a/sdk/cli/src/utils/subgraph/setup.ts
+++ b/sdk/cli/src/utils/subgraph/setup.ts
@@ -6,7 +6,7 @@ import { executeCommand } from "@settlemint/sdk-utils/terminal";
 import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import semver from "semver";
 import { missingApplication } from "@/error/missing-config-error";
-import { theGraphPrompt } from "@/prompts/cluster-service/thegraph.prompt";
+import { isHAGraphMiddleware, theGraphPrompt } from "@/prompts/cluster-service/thegraph.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
 import { executeFoundryCommand } from "../smart-contract-set/execute-foundry-command";
 import { sanitizeName } from "./sanitize-name";
@@ -94,7 +94,7 @@ export async function getTheGraphMiddleware({
   });
   if (autoAccept && env.SETTLEMINT_THEGRAPH) {
     const defaultTheGraphMiddleware = await settlemintClient.middleware.read(env.SETTLEMINT_THEGRAPH);
-    if (defaultTheGraphMiddleware && defaultTheGraphMiddleware.__typename === "HAGraphMiddleware") {
+    if (defaultTheGraphMiddleware && isHAGraphMiddleware(defaultTheGraphMiddleware)) {
       return defaultTheGraphMiddleware;
     }
   }

--- a/sdk/cli/src/utils/subgraph/setup.ts
+++ b/sdk/cli/src/utils/subgraph/setup.ts
@@ -6,7 +6,7 @@ import { executeCommand } from "@settlemint/sdk-utils/terminal";
 import { type DotEnv, LOCAL_INSTANCE, STANDALONE_INSTANCE } from "@settlemint/sdk-utils/validation";
 import semver from "semver";
 import { missingApplication } from "@/error/missing-config-error";
-import { isHAGraphMiddleware, theGraphPrompt } from "@/prompts/cluster-service/thegraph.prompt";
+import { isAnyHAGraphMiddleware, theGraphPrompt } from "@/prompts/cluster-service/thegraph.prompt";
 import { serviceSpinner } from "@/spinners/service.spinner";
 import { executeFoundryCommand } from "../smart-contract-set/execute-foundry-command";
 import { sanitizeName } from "./sanitize-name";
@@ -94,7 +94,7 @@ export async function getTheGraphMiddleware({
   });
   if (autoAccept && env.SETTLEMINT_THEGRAPH) {
     const defaultTheGraphMiddleware = await settlemintClient.middleware.read(env.SETTLEMINT_THEGRAPH);
-    if (defaultTheGraphMiddleware && isHAGraphMiddleware(defaultTheGraphMiddleware)) {
+    if (defaultTheGraphMiddleware && isAnyHAGraphMiddleware(defaultTheGraphMiddleware)) {
       return defaultTheGraphMiddleware;
     }
   }

--- a/sdk/js/src/graphql/middleware.ts
+++ b/sdk/js/src/graphql/middleware.ts
@@ -34,6 +34,19 @@ const MiddlewareFragment = graphql(`
     ... on HAGraphMiddleware {
       specVersion
     }
+    ... on HAGraphPostgresMiddleware {
+      specVersion
+    }
+  }
+`);
+
+const SubgraphFragment = graphql(`
+  fragment Subgraph on Subgraph {
+    name
+    graphqlQueryEndpoint {
+      displayValue
+      id
+    }
   }
 `);
 
@@ -82,17 +95,18 @@ const getGraphMiddlewareSubgraphs = graphql(
         ...Middleware
         ... on HAGraphMiddleware {
           subgraphs(noCache: $noCache) {
-            name
-            graphqlQueryEndpoint {
-              displayValue
-              id
-            }
+            ...Subgraph
+          }
+        }
+        ... on HAGraphPostgresMiddleware {
+          subgraphs(noCache: $noCache) {
+            ...Subgraph
           }
         }
       }
     }
   `,
-  [MiddlewareFragment],
+  [MiddlewareFragment, SubgraphFragment],
 );
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

Add support for the new HAGraphPostgresMiddleware type in SDK queries and CLI prompts, while refactoring subgraph queries, status checks, and environment setup to use shared fragments and utilities.

New Features:
- Add support for HAGraphPostgresMiddleware in GraphQL middleware fragments and queries
- Extend CLI to recognize HAGraphPostgresMiddleware alongside HAGraphMiddleware

Enhancements:
- Introduce a shared SubgraphFragment to DRY subgraph fields in GraphQL queries
- Replace direct status comparisons with a unified isRunning utility across service commands
- Update getGraphEnv and setup routines to use the extended isHAGraphMiddleware type guard