### PR TITLE
fix: the graph pagination

### DIFF
--- a/sdk/thegraph/src/thegraph.ts
+++ b/sdk/thegraph/src/thegraph.ts
@@ -105,8 +105,11 @@ export function createTheGraphClient<const Setup extends AbstractSetupSchema>(
     ...clientOptions,
     headers: appendHeaders(clientOptions?.headers, { "x-auth-token": validatedOptions.accessToken }),
   });
-  const paginatedClient = createTheGraphClientWithPagination(client);
-  client.request = paginatedClient.query as typeof client.request;
+  const originalRequest = client.request.bind(client);
+  const paginatedClient = createTheGraphClientWithPagination({
+    request: originalRequest,
+  });
+  client.request = paginatedClient.query;
   return {
     client,
     graphql,


### PR DESCRIPTION
## Summary by Sourcery

Improve TheGraph client pagination by enhancing directive stripping, streamlining default argument handling, and unifying query invocation to support both document strings and request options.

Bug Fixes:
- Ensure default pagination limits (first/skip) are consistently applied when using the @fetchAll directive.

Enhancements:
- Enable parsing and pagination for string-based RequestDocument inputs by integrating graphql parse in stripFetchAllDirective.
- Eliminate explicit hasFirst/hasSkip flags and simplify firstValue/skipValue determination with default fallback logic.
- Overload the query method to accept either a document plus variables or a RequestOptions object, using an isRequestOptions type guard.
- Preserve the original graphql-request client.request method and wrap it with the paginated client.query to integrate pagination correctly.