### PR TITLE
perf(viem): set polling interval to 500ms for improved responsiveness

### DIFF
--- a/sdk/viem/src/viem.ts
+++ b/sdk/viem/src/viem.ts
@@ -81,6 +81,7 @@ export const getPublicClient = (options: ClientOptions) => {
       chainName: validatedOptions.chainName,
       rpcUrl: validatedOptions.rpcUrl,
     }),
+    pollingInterval: 500,
     transport: http(validatedOptions.rpcUrl, {
       batch: true,
       timeout: 60_000,
@@ -151,6 +152,7 @@ export const getWalletClient = (options: ClientOptions) => {
   return (verificationOptions?: WalletVerificationOptions) =>
     createWalletClient({
       chain: chain,
+      pollingInterval: 500,
       transport: http(validatedOptions.rpcUrl, {
         batch: true,
         timeout: 60_000,


### PR DESCRIPTION
## Summary
Configures Viem blockchain clients with a 500ms polling interval to improve responsiveness when monitoring blockchain state changes. This reduces the default 4-second polling period, providing faster updates for applications.

## Changes
- Add `pollingInterval: 500` to `getPublicClient` configuration (sdk/viem/src/viem.ts:84)
- Add `pollingInterval: 500` to `getWalletClient` configuration (sdk/viem/src/viem.ts:155)

## Technical Details
The polling interval determines how frequently Viem clients check for blockchain updates (new blocks, transaction confirmations, etc.). By reducing this from the default 4000ms to 500ms, applications will receive updates 8x faster, improving user experience for real-time blockchain monitoring scenarios.

## Impact
- **Performance**: Faster detection of blockchain state changes
- **Network**: Increased RPC calls (8x more frequent polling)
- **Compatibility**: Fully backward compatible, no breaking changes
- **Resource Usage**: Slightly higher CPU and network utilization

## Testing
- TypeScript compilation verified
- Linting passed
- No existing tests affected (configuration-only change)

## Notes
Consider monitoring RPC endpoint usage to ensure the increased polling frequency doesn't approach rate limits. Future enhancement could make this configurable per use case.

## Summary by Sourcery

Enhancements:
- Reduce default polling interval from 4000ms to 500ms for viem public and wallet clients