### PR TITLE
feat(mcp): add JSON schemas for tool inputs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
         "commander": "14.0.0",
         "graphql": "16.11.0",
         "zod": "^4",
+        "zod-to-json-schema": "^3.23.0",
       },
     },
     "sdk/minio": {

--- a/sdk/mcp/README.md
+++ b/sdk/mcp/README.md
@@ -336,6 +336,29 @@ Using MCP in this scenario:
 In this use case, MCP enabled the AI to be a real-time guardian of the DeFi contract. Without MCP, the AI would not have access to the live on-chain state or the ability to execute a change. With MCP, the AI becomes a powerful autonomous agent that ensures the blockchain application adapts to current conditions.
 
 This is just one example. AI-driven blockchain applications could range from automatic NFT marketplace management, to AI moderators for DAO proposals, to intelligent supply chain contracts that react to sensor data. MCP provides the pathway for these AI agents to communicate and act where it matters - on the blockchain and connected systems.
+## Tool Input Schemas
+
+Every MCP tool under `src/tools` registers a JSON Schema describing its expected input. Clients can use these schemas for validation and auto-completion.
+
+| Tool | Input Schema |
+|------|--------------|
+| `prompts-list` | `{}` |
+| `prompts-get` | `{ category: string, name: string }` |
+| `resources-list` | `{}` |
+| `resources-get` | `{ name: string }` |
+| `portal-queries` | `{}` |
+| `portal-query` | `{ queryName: string }` |
+| `portal-mutations` | `{}` |
+| `portal-mutation` | `{ mutationName: string }` |
+| `hasura-queries` | `{}` |
+| `hasura-query` | `{ queryName: string }` |
+| `hasura-mutations` | `{}` |
+| `hasura-mutation` | `{ mutationName: string }` |
+| `thegraph-queries` | `{}` |
+| `thegraph-query` | `{ queryName: string }` |
+
+Platform tools (workspace, application, blockchain-network, etc.) follow the same pattern—each file in `src/tools/platform/**` defines a Zod schema that is converted to JSON Schema and passed to `server.tool` as `inputSchema`.
+
 ## Contributing
 
 We welcome contributions from the community! Please check out our [Contributing](https://github.com/settlemint/sdk/blob/main/.github/CONTRIBUTING.md) guide to learn how you can help improve the SettleMint SDK through bug reports, feature requests, documentation updates, or code contributions.

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -48,7 +48,8 @@
     "@settlemint/sdk-utils": "workspace:*",
     "commander": "14.0.0",
     "graphql": "16.11.0",
-    "zod": "^4"
+    "zod": "^4",
+    "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {},
   "peerDependencies": {},

--- a/sdk/mcp/src/tools/hasura/mutation.ts
+++ b/sdk/mcp/src/tools/hasura/mutation.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import type { GraphQLField } from "graphql";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import { generateFieldSDL } from "@/utils/sdl";
 
@@ -27,8 +28,16 @@ export const hasuraMutation = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({
+    mutationName: z.string(),
+  });
+
   // Tool for GraphQL mutations
-  server.tool("hasura-mutation", { mutationName: z.string() }, async ({ mutationName }) => {
+  server.tool(
+    "hasura-mutation",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { mutationName } = schema.parse(params);
     try {
       if (!mutationName) {
         return {
@@ -89,5 +98,6 @@ export const hasuraMutation = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/hasura/mutations.ts
+++ b/sdk/mcp/src/tools/hasura/mutations.ts
@@ -1,6 +1,8 @@
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const hasuraMutations = (server: McpServer, env: Partial<DotEnv>) => {
   const hasuraEndpoint = env.SETTLEMINT_HASURA_ENDPOINT;
@@ -23,8 +25,14 @@ export const hasuraMutations = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({});
+
   // Tool for GraphQL mutations
-  server.tool("hasura-mutations", async () => {
+  server.tool(
+    "hasura-mutations",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       const { mutationNames } = await fetchProcessedSchema(hasuraEndpoint, accessToken, hasuraAdminSecret);
 
@@ -50,5 +58,6 @@ export const hasuraMutations = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/hasura/queries.ts
+++ b/sdk/mcp/src/tools/hasura/queries.ts
@@ -1,6 +1,8 @@
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const hasuraQueries = (server: McpServer, env: Partial<DotEnv>) => {
   const hasuraEndpoint = env.SETTLEMINT_HASURA_ENDPOINT;
@@ -23,8 +25,14 @@ export const hasuraQueries = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({});
+
   // Tool for GraphQL queries
-  server.tool("hasura-queries", async () => {
+  server.tool(
+    "hasura-queries",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       const { queryNames } = await fetchProcessedSchema(hasuraEndpoint, accessToken, hasuraAdminSecret);
 
@@ -50,5 +58,6 @@ export const hasuraQueries = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/hasura/query.ts
+++ b/sdk/mcp/src/tools/hasura/query.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import type { GraphQLField } from "graphql";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import { generateFieldSDL } from "@/utils/sdl";
 
@@ -26,8 +27,14 @@ export const hasuraQuery = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({ queryName: z.string() });
+
   // Tool for GraphQL queries
-  server.tool("hasura-query", { queryName: z.string() }, async ({ queryName }) => {
+  server.tool(
+    "hasura-query",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { queryName } = schema.parse(params);
     try {
       if (!queryName) {
         return {
@@ -88,5 +95,6 @@ export const hasuraQuery = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/platform/application/list.ts
+++ b/sdk/mcp/src/tools/platform/application/list.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing applications in a workspace
@@ -28,19 +29,24 @@ export const platformApplicationList = (server: McpServer, env: Partial<DotEnv>,
     instance: instance,
   });
 
+  const schema = z.object({
+    workspaceUniqueName: z
+      .string()
+      .describe("Unique name of the workspace to list applications from"),
+  });
+
   server.tool(
     "platform-application-list",
-    {
-      workspaceUniqueName: z.string().describe("Unique name of the workspace to list applications from"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const applications = await client.application.list(params.workspaceUniqueName);
+      const { workspaceUniqueName } = schema.parse(params);
+      const applications = await client.application.list(workspaceUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Application List",
-            description: `List of applications in workspace: ${params.workspaceUniqueName}`,
+            description: `List of applications in workspace: ${workspaceUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(applications, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/application/read.ts
+++ b/sdk/mcp/src/tools/platform/application/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading an application by ID
@@ -28,19 +29,22 @@ export const platformApplicationRead = (server: McpServer, env: Partial<DotEnv>,
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z.string().describe("Unique name of the application to read"),
+  });
+
   server.tool(
     "platform-application-read",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const application = await client.application.read(params.applicationUniqueName);
+      const { applicationUniqueName } = schema.parse(params);
+      const application = await client.application.read(applicationUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Application Details",
-            description: `Details for application: ${params.applicationUniqueName}`,
+            description: `Details for application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(application, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/blockchain-network/create.ts
+++ b/sdk/mcp/src/tools/platform/blockchain-network/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new blockchain network
@@ -28,35 +29,43 @@ export const platformBlockchainNetworkCreate = (server: McpServer, env: Partial<
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the network in")
+      .optional(),
+    name: z.string().describe("Name of the blockchain network"),
+    type: z.enum(["DEDICATED", "SHARED"]).describe(
+      "Type of the blockchain network (DEDICATED or SHARED)",
+    ),
+    size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the blockchain network"),
+    provider: z.string().describe("Provider for the blockchain network"),
+    region: z.string().describe("Region for the blockchain network"),
+    nodeName: z.string().describe("Name for the initial node"),
+    consensusAlgorithm: z
+      .enum([
+        "ARBITRUM",
+        "ARBITRUM_GOERLI",
+        "ARBITRUM_SEPOLIA",
+        "AVALANCHE",
+        "AVALANCHE_FUJI",
+        "BESU_IBFTv2",
+        "BESU_QBFT",
+        "BSC_POW",
+        "BSC_POW_TESTNET",
+        "CORDA",
+        "FABRIC_RAFT",
+      ])
+      .describe("Consensus algorithm for the blockchain network"),
+  });
+
   server.tool(
     "platform-blockchain-network-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the network in").optional(),
-      name: z.string().describe("Name of the blockchain network"),
-      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the blockchain network (DEDICATED or SHARED)"),
-      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the blockchain network"),
-      provider: z.string().describe("Provider for the blockchain network"),
-      region: z.string().describe("Region for the blockchain network"),
-      nodeName: z.string().describe("Name for the initial node"),
-      consensusAlgorithm: z
-        .enum([
-          "ARBITRUM",
-          "ARBITRUM_GOERLI",
-          "ARBITRUM_SEPOLIA",
-          "AVALANCHE",
-          "AVALANCHE_FUJI",
-          "BESU_IBFTv2",
-          "BESU_QBFT",
-          "BSC_POW",
-          "BSC_POW_TESTNET",
-          "CORDA",
-          "FABRIC_RAFT",
-        ])
-        .describe("Consensus algorithm for the blockchain network"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
+      const parsed = schema.parse(params);
       // Prioritize environment variable over LLM-provided parameter for application
-      const applicationUniqueName = env.SETTLEMINT_APPLICATION || params.applicationUniqueName;
+      const applicationUniqueName = env.SETTLEMINT_APPLICATION || parsed.applicationUniqueName;
 
       if (!applicationUniqueName) {
         throw new Error(
@@ -69,13 +78,13 @@ export const platformBlockchainNetworkCreate = (server: McpServer, env: Partial<
 
       const network = await client.blockchainNetwork.create({
         applicationUniqueName,
-        name: params.name,
-        type: params.type,
-        size: params.size,
-        provider: params.provider,
-        region: params.region,
-        nodeName: params.nodeName,
-        consensusAlgorithm: params.consensusAlgorithm,
+        name: parsed.name,
+        type: parsed.type,
+        size: parsed.size,
+        provider: parsed.provider,
+        region: parsed.region,
+        nodeName: parsed.nodeName,
+        consensusAlgorithm: parsed.consensusAlgorithm,
       });
 
       return {
@@ -83,7 +92,7 @@ export const platformBlockchainNetworkCreate = (server: McpServer, env: Partial<
           {
             type: "text",
             name: "Blockchain Network Created",
-            description: `Created blockchain network: ${params.name} in application: ${applicationUniqueName}`,
+            description: `Created blockchain network: ${parsed.name} in application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(network, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/blockchain-network/read.ts
+++ b/sdk/mcp/src/tools/platform/blockchain-network/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a blockchain network by ID
@@ -28,14 +29,20 @@ export const platformBlockchainNetworkRead = (server: McpServer, env: Partial<Do
     instance: instance,
   });
 
+  const schema = z.object({
+    blockchainNetworkUniqueName: z
+      .string()
+      .describe("Unique name of the blockchain network to read")
+      .optional(),
+  });
+
   server.tool(
     "platform-blockchain-network-read",
-    {
-      blockchainNetworkUniqueName: z.string().describe("Unique name of the blockchain network to read").optional(),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
+      const { blockchainNetworkUniqueName: provided } = schema.parse(params);
       // Prioritize environment variable over LLM-provided parameter
-      const blockchainNetworkUniqueName = env.SETTLEMINT_BLOCKCHAIN_NETWORK || params.blockchainNetworkUniqueName;
+      const blockchainNetworkUniqueName = env.SETTLEMINT_BLOCKCHAIN_NETWORK || provided;
 
       if (!blockchainNetworkUniqueName) {
         throw new Error(

--- a/sdk/mcp/src/tools/platform/blockchain-node/list.ts
+++ b/sdk/mcp/src/tools/platform/blockchain-node/list.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing blockchain nodes in an application
@@ -28,19 +29,24 @@ export const platformBlockchainNodeList = (server: McpServer, env: Partial<DotEn
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to list blockchain nodes from"),
+  });
+
   server.tool(
     "platform-blockchain-node-list",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to list blockchain nodes from"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const nodes = await client.blockchainNode.list(params.applicationUniqueName);
+      const { applicationUniqueName } = schema.parse(params);
+      const nodes = await client.blockchainNode.list(applicationUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Blockchain Node List",
-            description: `List of blockchain nodes in application: ${params.applicationUniqueName}`,
+            description: `List of blockchain nodes in application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(nodes, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/blockchain-node/read.ts
+++ b/sdk/mcp/src/tools/platform/blockchain-node/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a blockchain node by ID
@@ -28,19 +29,22 @@ export const platformBlockchainNodeRead = (server: McpServer, env: Partial<DotEn
     instance: instance,
   });
 
+  const schema = z.object({
+    blockchainNodeUniqueName: z.string().describe("Unique name of the blockchain node to read"),
+  });
+
   server.tool(
     "platform-blockchain-node-read",
-    {
-      blockchainNodeUniqueName: z.string().describe("Unique name of the blockchain node to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const node = await client.blockchainNode.read(params.blockchainNodeUniqueName);
+      const { blockchainNodeUniqueName } = schema.parse(params);
+      const node = await client.blockchainNode.read(blockchainNodeUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Blockchain Node Details",
-            description: `Details for blockchain node: ${params.blockchainNodeUniqueName}`,
+            description: `Details for blockchain node: ${blockchainNodeUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(node, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/custom-deployment/read.ts
+++ b/sdk/mcp/src/tools/platform/custom-deployment/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a custom deployment by ID
@@ -28,19 +29,24 @@ export const platformCustomDeploymentRead = (server: McpServer, env: Partial<Dot
     instance: instance,
   });
 
+  const schema = z.object({
+    customDeploymentUniqueName: z.string().describe(
+      "Unique name of the custom deployment to read",
+    ),
+  });
+
   server.tool(
     "platform-custom-deployment-read",
-    {
-      customDeploymentUniqueName: z.string().describe("Unique name of the custom deployment to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const customDeployment = await client.customDeployment.read(params.customDeploymentUniqueName);
+      const { customDeploymentUniqueName } = schema.parse(params);
+      const customDeployment = await client.customDeployment.read(customDeploymentUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Custom Deployment Details",
-            description: `Details for custom deployment: ${params.customDeploymentUniqueName}`,
+            description: `Details for custom deployment: ${customDeploymentUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(customDeployment, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/custom-deployment/restart.ts
+++ b/sdk/mcp/src/tools/platform/custom-deployment/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting a custom deployment
@@ -28,19 +29,24 @@ export const platformCustomDeploymentRestart = (server: McpServer, env: Partial<
     instance: instance,
   });
 
+  const schema = z.object({
+    customDeploymentUniqueName: z.string().describe(
+      "Unique name of the custom deployment to restart",
+    ),
+  });
+
   server.tool(
     "platform-custom-deployment-restart",
-    {
-      customDeploymentUniqueName: z.string().describe("Unique name of the custom deployment to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const customDeployment = await client.customDeployment.restart(params.customDeploymentUniqueName);
+      const { customDeploymentUniqueName } = schema.parse(params);
+      const customDeployment = await client.customDeployment.restart(customDeploymentUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Custom Deployment Restarted",
-            description: `Restarted custom deployment: ${params.customDeploymentUniqueName}`,
+            description: `Restarted custom deployment: ${customDeploymentUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(customDeployment, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/insights/create.ts
+++ b/sdk/mcp/src/tools/platform/insights/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new insights instance
@@ -28,44 +29,53 @@ export const platformInsightsCreate = (server: McpServer, env: Partial<DotEnv>, 
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the insights in"),
+    name: z.string().describe("Name of the insights"),
+    type: z.enum(["DEDICATED", "SHARED"]).describe(
+      "Type of the insights (DEDICATED or SHARED)",
+    ),
+    size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the insights"),
+    provider: z.string().describe("Provider for the insights"),
+    region: z.string().describe("Region for the insights"),
+    insightsCategory: z
+      .enum(["BLOCKCHAIN_EXPLORER", "HYPERLEDGER_EXPLORER", "OTTERSCAN_BLOCKCHAIN_EXPLORER"])
+      .describe("Category of insights"),
+    blockchainNodeUniqueName: z
+      .string()
+      .optional()
+      .describe(
+        "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName)",
+      ),
+    loadBalancerUniqueName: z
+      .string()
+      .optional()
+      .describe(
+        "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), prefer using a load balancer if available",
+      ),
+  });
+
   server.tool(
     "platform-insights-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the insights in"),
-      name: z.string().describe("Name of the insights"),
-      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the insights (DEDICATED or SHARED)"),
-      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the insights"),
-      provider: z.string().describe("Provider for the insights"),
-      region: z.string().describe("Region for the insights"),
-      insightsCategory: z
-        .enum(["BLOCKCHAIN_EXPLORER", "HYPERLEDGER_EXPLORER", "OTTERSCAN_BLOCKCHAIN_EXPLORER"])
-        .describe("Category of insights"),
-      blockchainNodeUniqueName: z
-        .string()
-        .optional()
-        .describe("Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName)"),
-      loadBalancerUniqueName: z
-        .string()
-        .optional()
-        .describe(
-          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), prefer using a load balancer if available",
-        ),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      if (params.blockchainNodeUniqueName && params.loadBalancerUniqueName) {
+      const parsed = schema.parse(params);
+      if (parsed.blockchainNodeUniqueName && parsed.loadBalancerUniqueName) {
         throw new Error("Only one of 'blockchainNodeUniqueName' and 'loadBalancerUniqueName' may be provided");
       }
 
       const insights = await client.insights.create({
-        applicationUniqueName: params.applicationUniqueName,
-        name: params.name,
-        type: params.type,
-        size: params.size,
-        provider: params.provider,
-        region: params.region,
-        insightsCategory: params.insightsCategory,
-        blockchainNodeUniqueName: params.blockchainNodeUniqueName,
-        loadBalancerUniqueName: params.loadBalancerUniqueName,
+        applicationUniqueName: parsed.applicationUniqueName,
+        name: parsed.name,
+        type: parsed.type,
+        size: parsed.size,
+        provider: parsed.provider,
+        region: parsed.region,
+        insightsCategory: parsed.insightsCategory,
+        blockchainNodeUniqueName: parsed.blockchainNodeUniqueName,
+        loadBalancerUniqueName: parsed.loadBalancerUniqueName,
       });
 
       return {
@@ -73,7 +83,7 @@ export const platformInsightsCreate = (server: McpServer, env: Partial<DotEnv>, 
           {
             type: "text",
             name: "Insights Created",
-            description: `Created insights: ${params.name} in application: ${params.applicationUniqueName}`,
+            description: `Created insights: ${parsed.name} in application: ${parsed.applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(insights, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/insights/read.ts
+++ b/sdk/mcp/src/tools/platform/insights/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading an insights instance by ID
@@ -28,19 +29,22 @@ export const platformInsightsRead = (server: McpServer, env: Partial<DotEnv>, pa
     instance: instance,
   });
 
+  const schema = z.object({
+    insightsUniqueName: z.string().describe("Unique name of the insights to read"),
+  });
+
   server.tool(
     "platform-insights-read",
-    {
-      insightsUniqueName: z.string().describe("Unique name of the insights to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const insights = await client.insights.read(params.insightsUniqueName);
+      const { insightsUniqueName } = schema.parse(params);
+      const insights = await client.insights.read(insightsUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Insights Details",
-            description: `Details for insights: ${params.insightsUniqueName}`,
+            description: `Details for insights: ${insightsUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(insights, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/insights/restart.ts
+++ b/sdk/mcp/src/tools/platform/insights/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting an insights instance
@@ -28,19 +29,22 @@ export const platformInsightsRestart = (server: McpServer, env: Partial<DotEnv>,
     instance: instance,
   });
 
+  const schema = z.object({
+    insightsUniqueName: z.string().describe("Unique name of the insights to restart"),
+  });
+
   server.tool(
     "platform-insights-restart",
-    {
-      insightsUniqueName: z.string().describe("Unique name of the insights to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const insights = await client.insights.restart(params.insightsUniqueName);
+      const { insightsUniqueName } = schema.parse(params);
+      const insights = await client.insights.restart(insightsUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Insights Restarted",
-            description: `Restarted insights: ${params.insightsUniqueName}`,
+            description: `Restarted insights: ${insightsUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(insights, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/integration-tool/read.ts
+++ b/sdk/mcp/src/tools/platform/integration-tool/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading an integration tool by ID
@@ -28,19 +29,26 @@ export const platformIntegrationToolRead = (server: McpServer, env: Partial<DotE
     instance: instance,
   });
 
+  const schema = z.object({
+    integrationToolUniqueName: z
+      .string()
+      .describe("Unique name of the integration tool to read"),
+  });
+
   server.tool(
     "platform-integration-tool-read",
-    {
-      integrationToolUniqueName: z.string().describe("Unique name of the integration tool to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const integrationTool = await client.integrationTool.read(params.integrationToolUniqueName);
+      const { integrationToolUniqueName } = schema.parse(params);
+      const integrationTool = await client.integrationTool.read(
+        integrationToolUniqueName,
+      );
       return {
         content: [
           {
             type: "text",
             name: "Integration Tool Details",
-            description: `Details for integration tool: ${params.integrationToolUniqueName}`,
+            description: `Details for integration tool: ${integrationToolUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(integrationTool, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/integration-tool/restart.ts
+++ b/sdk/mcp/src/tools/platform/integration-tool/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting an integration tool
@@ -28,19 +29,26 @@ export const platformIntegrationToolRestart = (server: McpServer, env: Partial<D
     instance: instance,
   });
 
+  const schema = z.object({
+    integrationToolUniqueName: z
+      .string()
+      .describe("Unique name of the integration tool to restart"),
+  });
+
   server.tool(
     "platform-integration-tool-restart",
-    {
-      integrationToolUniqueName: z.string().describe("Unique name of the integration tool to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const integrationTool = await client.integrationTool.restart(params.integrationToolUniqueName);
+      const { integrationToolUniqueName } = schema.parse(params);
+      const integrationTool = await client.integrationTool.restart(
+        integrationToolUniqueName,
+      );
       return {
         content: [
           {
             type: "text",
             name: "Integration Tool Restarted",
-            description: `Restarted integration tool: ${params.integrationToolUniqueName}`,
+            description: `Restarted integration tool: ${integrationToolUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(integrationTool, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/load-balancer/create.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new load balancer
@@ -28,30 +29,39 @@ export const platformLoadBalancerCreate = (server: McpServer, env: Partial<DotEn
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the load balancer in"),
+    name: z.string().describe("Name of the load balancer"),
+    type: z.enum(["DEDICATED", "SHARED"]).describe(
+      "Type of the load balancer (DEDICATED or SHARED)",
+    ),
+    size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the load balancer"),
+    provider: z.string().describe("Provider for the load balancer"),
+    region: z.string().describe("Region for the load balancer"),
+    blockchainNetworkUniqueName: z
+      .string()
+      .describe("Unique name of the blockchain network for the load balancer"),
+    connectedNodesUniqueNames: z
+      .array(z.string())
+      .describe("Unique names of the nodes to connect to the load balancer"),
+  });
+
   server.tool(
     "platform-load-balancer-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the load balancer in"),
-      name: z.string().describe("Name of the load balancer"),
-      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the load balancer (DEDICATED or SHARED)"),
-      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the load balancer"),
-      provider: z.string().describe("Provider for the load balancer"),
-      region: z.string().describe("Region for the load balancer"),
-      blockchainNetworkUniqueName: z.string().describe("Unique name of the blockchain network for the load balancer"),
-      connectedNodesUniqueNames: z
-        .array(z.string())
-        .describe("Unique names of the nodes to connect to the load balancer"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
+      const parsed = schema.parse(params);
       const loadBalancer = await client.loadBalancer.create({
-        applicationUniqueName: params.applicationUniqueName,
-        name: params.name,
-        type: params.type,
-        size: params.size,
-        provider: params.provider,
-        region: params.region,
-        blockchainNetworkUniqueName: params.blockchainNetworkUniqueName,
-        connectedNodesUniqueNames: params.connectedNodesUniqueNames,
+        applicationUniqueName: parsed.applicationUniqueName,
+        name: parsed.name,
+        type: parsed.type,
+        size: parsed.size,
+        provider: parsed.provider,
+        region: parsed.region,
+        blockchainNetworkUniqueName: parsed.blockchainNetworkUniqueName,
+        connectedNodesUniqueNames: parsed.connectedNodesUniqueNames,
       });
 
       return {
@@ -59,7 +69,7 @@ export const platformLoadBalancerCreate = (server: McpServer, env: Partial<DotEn
           {
             type: "text",
             name: "Load Balancer Created",
-            description: `Created load balancer: ${params.name} in application: ${params.applicationUniqueName}`,
+            description: `Created load balancer: ${parsed.name} in application: ${parsed.applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(loadBalancer, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/load-balancer/restart.ts
+++ b/sdk/mcp/src/tools/platform/load-balancer/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting a load balancer
@@ -28,19 +29,24 @@ export const platformLoadBalancerRestart = (server: McpServer, env: Partial<DotE
     instance: instance,
   });
 
+  const schema = z.object({
+    loadBalancerUniqueName: z
+      .string()
+      .describe("Unique name of the load balancer to restart"),
+  });
+
   server.tool(
     "platform-load-balancer-restart",
-    {
-      loadBalancerUniqueName: z.string().describe("Unique name of the load balancer to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const loadBalancer = await client.loadBalancer.restart(params.loadBalancerUniqueName);
+      const { loadBalancerUniqueName } = schema.parse(params);
+      const loadBalancer = await client.loadBalancer.restart(loadBalancerUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Load Balancer Restarted",
-            description: `Restarted load balancer: ${params.loadBalancerUniqueName}`,
+            description: `Restarted load balancer: ${loadBalancerUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(loadBalancer, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/middleware/create.ts
+++ b/sdk/mcp/src/tools/platform/middleware/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new middleware
@@ -28,46 +29,53 @@ export const platformMiddlewareCreate = (server: McpServer, env: Partial<DotEnv>
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the middleware in"),
+    name: z.string().describe("Name of the middleware"),
+    type: z.enum(["DEDICATED", "SHARED"]).describe(
+      "Type of the middleware (DEDICATED or SHARED)",
+    ),
+    size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the middleware"),
+    provider: z.string().describe("Provider for the middleware"),
+    region: z.string().describe("Region for the middleware"),
+    interface: z
+      .enum(["ATTESTATION_INDEXER", "BESU", "FIREFLY_FABCONNECT", "GRAPH", "HA_GRAPH", "SMART_CONTRACT_PORTAL"])
+      .describe("Interface type for the middleware"),
+    blockchainNodeUniqueName: z
+      .string()
+      .optional()
+      .describe(
+        "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName), preferred option for interface SMART_CONTRACT_PORTAL",
+      ),
+    loadBalancerUniqueName: z
+      .string()
+      .optional()
+      .describe(
+        "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), preferred option for all other interfaces",
+      ),
+  });
+
   server.tool(
     "platform-middleware-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the middleware in"),
-      name: z.string().describe("Name of the middleware"),
-      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the middleware (DEDICATED or SHARED)"),
-      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the middleware"),
-      provider: z.string().describe("Provider for the middleware"),
-      region: z.string().describe("Region for the middleware"),
-      interface: z
-        .enum(["ATTESTATION_INDEXER", "BESU", "FIREFLY_FABCONNECT", "GRAPH", "HA_GRAPH", "SMART_CONTRACT_PORTAL"])
-        .describe("Interface type for the middleware"),
-      blockchainNodeUniqueName: z
-        .string()
-        .optional()
-        .describe(
-          "Unique name of the blockchain node to connect to (mutually exclusive with loadBalancerUniqueName), preferred option for interface SMART_CONTRACT_PORTAL",
-        ),
-      loadBalancerUniqueName: z
-        .string()
-        .optional()
-        .describe(
-          "Unique name of the load balancer to connect to (mutually exclusive with blockchainNodeUniqueName), preferred option for all other interfaces",
-        ),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      if (params.blockchainNodeUniqueName && params.loadBalancerUniqueName) {
+      const parsed = schema.parse(params);
+      if (parsed.blockchainNodeUniqueName && parsed.loadBalancerUniqueName) {
         throw new Error("Only one of 'blockchainNodeUniqueName' and 'loadBalancerUniqueName' may be provided");
       }
 
       const middleware = await client.middleware.create({
-        applicationUniqueName: params.applicationUniqueName,
-        name: params.name,
-        type: params.type,
-        size: params.size,
-        provider: params.provider,
-        region: params.region,
-        interface: params.interface,
-        blockchainNodeUniqueName: params.blockchainNodeUniqueName,
-        loadBalancerUniqueName: params.loadBalancerUniqueName,
+        applicationUniqueName: parsed.applicationUniqueName,
+        name: parsed.name,
+        type: parsed.type,
+        size: parsed.size,
+        provider: parsed.provider,
+        region: parsed.region,
+        interface: parsed.interface,
+        blockchainNodeUniqueName: parsed.blockchainNodeUniqueName,
+        loadBalancerUniqueName: parsed.loadBalancerUniqueName,
       });
 
       return {
@@ -75,7 +83,7 @@ export const platformMiddlewareCreate = (server: McpServer, env: Partial<DotEnv>
           {
             type: "text",
             name: "Middleware Created",
-            description: `Created middleware: ${params.name} in application: ${params.applicationUniqueName}`,
+            description: `Created middleware: ${parsed.name} in application: ${parsed.applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(middleware, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/middleware/list.ts
+++ b/sdk/mcp/src/tools/platform/middleware/list.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing middleware instances
@@ -28,19 +29,24 @@ export const platformMiddlewareList = (server: McpServer, env: Partial<DotEnv>, 
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to list middleware from"),
+  });
+
   server.tool(
     "platform-middleware-list",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to list middleware from"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const middlewareList = await client.middleware.list(params.applicationUniqueName);
+      const { applicationUniqueName } = schema.parse(params);
+      const middlewareList = await client.middleware.list(applicationUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Middleware List",
-            description: `List of middleware in application: ${params.applicationUniqueName}`,
+            description: `List of middleware in application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(middlewareList, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/middleware/read.ts
+++ b/sdk/mcp/src/tools/platform/middleware/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a middleware by ID
@@ -28,19 +29,22 @@ export const platformMiddlewareRead = (server: McpServer, env: Partial<DotEnv>, 
     instance: instance,
   });
 
+  const schema = z.object({
+    middlewareUniqueName: z.string().describe("Unique name of the middleware to read"),
+  });
+
   server.tool(
     "platform-middleware-read",
-    {
-      middlewareUniqueName: z.string().describe("Unique name of the middleware to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const middleware = await client.middleware.read(params.middlewareUniqueName);
+      const { middlewareUniqueName } = schema.parse(params);
+      const middleware = await client.middleware.read(middlewareUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Middleware Details",
-            description: `Details for middleware: ${params.middlewareUniqueName}`,
+            description: `Details for middleware: ${middlewareUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(middleware, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/middleware/restart.ts
+++ b/sdk/mcp/src/tools/platform/middleware/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting a middleware
@@ -28,19 +29,24 @@ export const platformMiddlewareRestart = (server: McpServer, env: Partial<DotEnv
     instance: instance,
   });
 
+  const schema = z.object({
+    middlewareUniqueName: z.string().describe(
+      "Unique name of the middleware to restart",
+    ),
+  });
+
   server.tool(
     "platform-middleware-restart",
-    {
-      middlewareUniqueName: z.string().describe("Unique name of the middleware to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const middleware = await client.middleware.restart(params.middlewareUniqueName);
+      const { middlewareUniqueName } = schema.parse(params);
+      const middleware = await client.middleware.restart(middlewareUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Middleware Restarted",
-            description: `Restarted middleware: ${params.middlewareUniqueName}`,
+            description: `Restarted middleware: ${middlewareUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(middleware, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/private-key/create.ts
+++ b/sdk/mcp/src/tools/platform/private-key/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new private key
@@ -28,25 +29,30 @@ export const platformPrivateKeyCreate = (server: McpServer, env: Partial<DotEnv>
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the private key in"),
+    name: z.string().describe("Name of the private key"),
+    privateKeyType: z
+      .enum(["ACCESSIBLE_ECDSA_P256", "HD_ECDSA_P256", "HSM_ECDSA_P256"])
+      .describe("Type of private key"),
+    blockchainNodeUniqueNames: z
+      .array(z.string())
+      .optional()
+      .describe("Unique names of blockchain nodes to associate with the private key"),
+  });
+
   server.tool(
     "platform-private-key-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the private key in"),
-      name: z.string().describe("Name of the private key"),
-      privateKeyType: z
-        .enum(["ACCESSIBLE_ECDSA_P256", "HD_ECDSA_P256", "HSM_ECDSA_P256"])
-        .describe("Type of private key"),
-      blockchainNodeUniqueNames: z
-        .array(z.string())
-        .optional()
-        .describe("Unique names of blockchain nodes to associate with the private key"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
+      const parsed = schema.parse(params);
       const privateKey = await client.privateKey.create({
-        applicationUniqueName: params.applicationUniqueName,
-        name: params.name,
-        privateKeyType: params.privateKeyType,
-        blockchainNodeUniqueNames: params.blockchainNodeUniqueNames,
+        applicationUniqueName: parsed.applicationUniqueName,
+        name: parsed.name,
+        privateKeyType: parsed.privateKeyType,
+        blockchainNodeUniqueNames: parsed.blockchainNodeUniqueNames,
       });
 
       return {
@@ -54,7 +60,7 @@ export const platformPrivateKeyCreate = (server: McpServer, env: Partial<DotEnv>
           {
             type: "text",
             name: "Private Key Created",
-            description: `Created private key: ${params.name} in application: ${params.applicationUniqueName}`,
+            description: `Created private key: ${parsed.name} in application: ${parsed.applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(privateKey, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/private-key/list.ts
+++ b/sdk/mcp/src/tools/platform/private-key/list.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing private keys
@@ -28,19 +29,24 @@ export const platformPrivateKeyList = (server: McpServer, env: Partial<DotEnv>, 
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to list private keys from"),
+  });
+
   server.tool(
     "platform-private-key-list",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to list private keys from"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const privateKeys = await client.privateKey.list(params.applicationUniqueName);
+      const { applicationUniqueName } = schema.parse(params);
+      const privateKeys = await client.privateKey.list(applicationUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Private Key List",
-            description: `List of private keys in application: ${params.applicationUniqueName}`,
+            description: `List of private keys in application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(privateKeys, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/private-key/restart.ts
+++ b/sdk/mcp/src/tools/platform/private-key/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting a private key
@@ -28,19 +29,24 @@ export const platformPrivateKeyRestart = (server: McpServer, env: Partial<DotEnv
     instance: instance,
   });
 
+  const schema = z.object({
+    privateKeyUniqueName: z
+      .string()
+      .describe("Unique name of the private key to restart"),
+  });
+
   server.tool(
     "platform-private-key-restart",
-    {
-      privateKeyUniqueName: z.string().describe("Unique name of the private key to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const privateKey = await client.privateKey.restart(params.privateKeyUniqueName);
+      const { privateKeyUniqueName } = schema.parse(params);
+      const privateKey = await client.privateKey.restart(privateKeyUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Private Key Restarted",
-            description: `Restarted private key: ${params.privateKeyUniqueName}`,
+            description: `Restarted private key: ${privateKeyUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(privateKey, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/storage/create.ts
+++ b/sdk/mcp/src/tools/platform/storage/create.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for creating a new storage instance
@@ -28,26 +29,35 @@ export const platformStorageCreate = (server: McpServer, env: Partial<DotEnv>, p
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to create the storage in"),
+    name: z.string().describe("Name of the storage"),
+    type: z.enum(["DEDICATED", "SHARED"]).describe(
+      "Type of the storage (DEDICATED or SHARED)",
+    ),
+    size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the storage"),
+    provider: z.string().describe("Provider for the storage"),
+    region: z.string().describe("Region for the storage"),
+    storageProtocol: z.enum(["IPFS", "MINIO"]).describe(
+      "Storage protocol (IPFS or MINIO)",
+    ),
+  });
+
   server.tool(
     "platform-storage-create",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to create the storage in"),
-      name: z.string().describe("Name of the storage"),
-      type: z.enum(["DEDICATED", "SHARED"]).describe("Type of the storage (DEDICATED or SHARED)"),
-      size: z.enum(["SMALL", "MEDIUM", "LARGE"]).describe("Size of the storage"),
-      provider: z.string().describe("Provider for the storage"),
-      region: z.string().describe("Region for the storage"),
-      storageProtocol: z.enum(["IPFS", "MINIO"]).describe("Storage protocol (IPFS or MINIO)"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
+      const parsed = schema.parse(params);
       const storage = await client.storage.create({
-        applicationUniqueName: params.applicationUniqueName,
-        name: params.name,
-        type: params.type,
-        size: params.size,
-        provider: params.provider,
-        region: params.region,
-        storageProtocol: params.storageProtocol,
+        applicationUniqueName: parsed.applicationUniqueName,
+        name: parsed.name,
+        type: parsed.type,
+        size: parsed.size,
+        provider: parsed.provider,
+        region: parsed.region,
+        storageProtocol: parsed.storageProtocol,
       });
 
       return {
@@ -55,7 +65,7 @@ export const platformStorageCreate = (server: McpServer, env: Partial<DotEnv>, p
           {
             type: "text",
             name: "Storage Created",
-            description: `Created storage: ${params.name} in application: ${params.applicationUniqueName}`,
+            description: `Created storage: ${parsed.name} in application: ${parsed.applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(storage, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/storage/list.ts
+++ b/sdk/mcp/src/tools/platform/storage/list.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing storage instances
@@ -28,19 +29,24 @@ export const platformStorageList = (server: McpServer, env: Partial<DotEnv>, pat
     instance: instance,
   });
 
+  const schema = z.object({
+    applicationUniqueName: z
+      .string()
+      .describe("Unique name of the application to list storage from"),
+  });
+
   server.tool(
     "platform-storage-list",
-    {
-      applicationUniqueName: z.string().describe("Unique name of the application to list storage from"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const storageList = await client.storage.list(params.applicationUniqueName);
+      const { applicationUniqueName } = schema.parse(params);
+      const storageList = await client.storage.list(applicationUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Storage List",
-            description: `List of storage in application: ${params.applicationUniqueName}`,
+            description: `List of storage in application: ${applicationUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(storageList, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/storage/read.ts
+++ b/sdk/mcp/src/tools/platform/storage/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a storage instance by ID
@@ -28,19 +29,22 @@ export const platformStorageRead = (server: McpServer, env: Partial<DotEnv>, pat
     instance: instance,
   });
 
+  const schema = z.object({
+    storageUniqueName: z.string().describe("Unique name of the storage to read"),
+  });
+
   server.tool(
     "platform-storage-read",
-    {
-      storageUniqueName: z.string().describe("Unique name of the storage to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const storage = await client.storage.read(params.storageUniqueName);
+      const { storageUniqueName } = schema.parse(params);
+      const storage = await client.storage.read(storageUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Storage Details",
-            description: `Details for storage: ${params.storageUniqueName}`,
+            description: `Details for storage: ${storageUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(storage, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/storage/restart.ts
+++ b/sdk/mcp/src/tools/platform/storage/restart.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for restarting a storage instance
@@ -28,19 +29,22 @@ export const platformStorageRestart = (server: McpServer, env: Partial<DotEnv>, 
     instance: instance,
   });
 
+  const schema = z.object({
+    storageUniqueName: z.string().describe("Unique name of the storage to restart"),
+  });
+
   server.tool(
     "platform-storage-restart",
-    {
-      storageUniqueName: z.string().describe("Unique name of the storage to restart"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const storage = await client.storage.restart(params.storageUniqueName);
+      const { storageUniqueName } = schema.parse(params);
+      const storage = await client.storage.restart(storageUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Storage Restarted",
-            description: `Restarted storage: ${params.storageUniqueName}`,
+            description: `Restarted storage: ${storageUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(storage, null, 2),
           },

--- a/sdk/mcp/src/tools/platform/workspace/list.ts
+++ b/sdk/mcp/src/tools/platform/workspace/list.ts
@@ -1,6 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for listing all workspaces
@@ -27,18 +29,25 @@ export const platformWorkspaceList = (server: McpServer, env: Partial<DotEnv>, p
     instance: instance,
   });
 
-  server.tool("platform-workspace-list", {}, async () => {
-    const workspaces = await client.workspace.list();
-    return {
-      content: [
-        {
-          type: "text",
-          name: "Workspace List",
-          description: "List of workspaces",
-          mimeType: "application/json",
-          text: JSON.stringify(workspaces, null, 2),
-        },
-      ],
-    };
-  });
+  const schema = z.object({});
+
+  server.tool(
+    "platform-workspace-list",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
+      const workspaces = await client.workspace.list();
+      return {
+        content: [
+          {
+            type: "text",
+            name: "Workspace List",
+            description: "List of workspaces",
+            mimeType: "application/json",
+            text: JSON.stringify(workspaces, null, 2),
+          },
+        ],
+      };
+    },
+  );
 };

--- a/sdk/mcp/src/tools/platform/workspace/read.ts
+++ b/sdk/mcp/src/tools/platform/workspace/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createSettleMintClient } from "@settlemint/sdk-js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Creates a tool for reading a workspace by ID
@@ -28,19 +29,22 @@ export const platformWorkspaceRead = (server: McpServer, env: Partial<DotEnv>, p
     instance: instance,
   });
 
+  const schema = z.object({
+    workspaceUniqueName: z.string().describe("Unique name of the workspace to read"),
+  });
+
   server.tool(
     "platform-workspace-read",
-    {
-      workspaceUniqueName: z.string().describe("Unique name of the workspace to read"),
-    },
+    { inputSchema: zodToJsonSchema(schema) },
     async (params) => {
-      const workspace = await client.workspace.read(params.workspaceUniqueName);
+      const { workspaceUniqueName } = schema.parse(params);
+      const workspace = await client.workspace.read(workspaceUniqueName);
       return {
         content: [
           {
             type: "text",
             name: "Workspace Details",
-            description: `Details for workspace: ${params.workspaceUniqueName}`,
+            description: `Details for workspace: ${workspaceUniqueName}`,
             mimeType: "application/json",
             text: JSON.stringify(workspace, null, 2),
           },

--- a/sdk/mcp/src/tools/portal/mutation.ts
+++ b/sdk/mcp/src/tools/portal/mutation.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import type { GraphQLField } from "graphql";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import { generateFieldSDL } from "@/utils/sdl";
 
@@ -20,8 +21,14 @@ export const portalMutation = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({ mutationName: z.string() });
+
   // Tool for GraphQL mutations
-  server.tool("portal-mutation", { mutationName: z.string() }, async ({ mutationName }) => {
+  server.tool(
+    "portal-mutation",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { mutationName } = schema.parse(params);
     try {
       if (!mutationName) {
         return {
@@ -82,5 +89,6 @@ export const portalMutation = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/portal/mutations.ts
+++ b/sdk/mcp/src/tools/portal/mutations.ts
@@ -1,6 +1,8 @@
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const portalMutations = (server: McpServer, env: Partial<DotEnv>) => {
   // Check if portal GraphQL endpoint exists in environment variables
@@ -17,8 +19,14 @@ export const portalMutations = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({});
+
   // Tool for GraphQL mutations
-  server.tool("portal-mutations", async () => {
+  server.tool(
+    "portal-mutations",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       const { mutationNames } = await fetchProcessedSchema(portalGraphqlEndpoint, accessToken);
 
@@ -44,5 +52,6 @@ export const portalMutations = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/portal/queries.ts
+++ b/sdk/mcp/src/tools/portal/queries.ts
@@ -1,6 +1,8 @@
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const portalQueries = (server: McpServer, env: Partial<DotEnv>) => {
   // Check if portal GraphQL endpoint exists in environment variables
@@ -17,8 +19,14 @@ export const portalQueries = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({});
+
   // Tool for GraphQL queries
-  server.tool("portal-queries", async () => {
+  server.tool(
+    "portal-queries",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       const { queryNames } = await fetchProcessedSchema(portalGraphqlEndpoint, accessToken);
 
@@ -44,5 +52,6 @@ export const portalQueries = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/portal/query.ts
+++ b/sdk/mcp/src/tools/portal/query.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import type { GraphQLField } from "graphql";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import { generateFieldSDL } from "@/utils/sdl";
 
@@ -20,8 +21,14 @@ export const portalQuery = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({ queryName: z.string() });
+
   // Tool for GraphQL queries
-  server.tool("portal-query", { queryName: z.string() }, async ({ queryName }) => {
+  server.tool(
+    "portal-query",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { queryName } = schema.parse(params);
     try {
       if (!queryName) {
         return {
@@ -82,5 +89,6 @@ export const portalQuery = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/prompts/get.ts
+++ b/sdk/mcp/src/tools/prompts/get.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Registers a tool to get a specific prompt from the SDK
@@ -16,13 +17,16 @@ import { z } from "zod";
  * promptsGet(server, env);
  */
 export const promptsGet = (server: McpServer, _env: Partial<DotEnv>) => {
+  const schema = z.object({
+    category: z.string().describe("The prompt category (e.g., hasura, portal, thegraph, tool-usage)"),
+    name: z.string().describe("The name of the prompt file without extension"),
+  });
+
   server.tool(
     "prompts-get",
-    {
-      category: z.string().describe("The prompt category (e.g., hasura, portal, thegraph, tool-usage)"),
-      name: z.string().describe("The name of the prompt file without extension"),
-    },
-    async ({ category, name }) => {
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { category, name } = schema.parse(params);
       try {
         // Get the prompts directory path
         const promptsDir = path.resolve(__dirname, "../../prompts");

--- a/sdk/mcp/src/tools/prompts/list.ts
+++ b/sdk/mcp/src/tools/prompts/list.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Registers a tool to list available prompts in the SDK
@@ -15,7 +17,13 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
  * promptsList(server, env);
  */
 export const promptsList = (server: McpServer, _env: Partial<DotEnv>) => {
-  server.tool("prompts-list", {}, async () => {
+  const schema = z.object({});
+
+  server.tool(
+    "prompts-list",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       // Get the prompts directory path
       const promptsDir = path.resolve(__dirname, "../../prompts");
@@ -78,5 +86,6 @@ export const promptsList = (server: McpServer, _env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/resources/get.ts
+++ b/sdk/mcp/src/tools/resources/get.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Registers a tool to get a specific resource from the SDK
@@ -16,12 +17,15 @@ import { z } from "zod";
  * resourcesGet(server, env);
  */
 export const resourcesGet = (server: McpServer, _env: Partial<DotEnv>) => {
+  const schema = z.object({
+    name: z.string().describe("The name of the resource file without extension"),
+  });
+
   server.tool(
     "resources-get",
-    {
-      name: z.string().describe("The name of the resource file without extension"),
-    },
-    async ({ name }) => {
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { name } = schema.parse(params);
       try {
         // Get the resources directory path
         const resourcesDir = path.resolve(__dirname, "../../resources");

--- a/sdk/mcp/src/tools/resources/list.ts
+++ b/sdk/mcp/src/tools/resources/list.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 /**
  * Registers a tool to list available resources in the SDK
@@ -15,7 +17,13 @@ import type { DotEnv } from "@settlemint/sdk-utils/validation";
  * resourcesList(server, env);
  */
 export const resourcesList = (server: McpServer, _env: Partial<DotEnv>) => {
-  server.tool("resources-list", {}, async () => {
+  const schema = z.object({});
+
+  server.tool(
+    "resources-list",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       // Get the resources directory path
       const resourcesDir = path.resolve(__dirname, "../../resources");
@@ -59,5 +67,6 @@ export const resourcesList = (server: McpServer, _env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/thegraph/queries.ts
+++ b/sdk/mcp/src/tools/thegraph/queries.ts
@@ -1,6 +1,8 @@
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const thegraphQueries = (server: McpServer, env: Partial<DotEnv>) => {
   // Get the default subgraph name and endpoints array
@@ -25,8 +27,14 @@ export const thegraphQueries = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({});
+
   // Tool for GraphQL queries
-  server.tool("thegraph-queries", async () => {
+  server.tool(
+    "thegraph-queries",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      schema.parse(params);
     try {
       const { queryNames } = await fetchProcessedSchema(thegraphGraphqlEndpoint, accessToken);
 
@@ -52,5 +60,6 @@ export const thegraphQueries = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };

--- a/sdk/mcp/src/tools/thegraph/query.ts
+++ b/sdk/mcp/src/tools/thegraph/query.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { DotEnv } from "@settlemint/sdk-utils/validation";
 import type { GraphQLField } from "graphql";
 import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { fetchProcessedSchema } from "@/utils/schema-processor";
 import { generateFieldSDL } from "@/utils/sdl";
 
@@ -28,8 +29,14 @@ export const thegraphQuery = (server: McpServer, env: Partial<DotEnv>) => {
     throw new Error("Access token not found in environment variables. Please set SETTLEMINT_ACCESS_TOKEN.");
   }
 
+  const schema = z.object({ queryName: z.string() });
+
   // Tool for GraphQL queries
-  server.tool("thegraph-query", { queryName: z.string() }, async ({ queryName }) => {
+  server.tool(
+    "thegraph-query",
+    { inputSchema: zodToJsonSchema(schema) },
+    async (params) => {
+      const { queryName } = schema.parse(params);
     try {
       if (!queryName) {
         return {
@@ -90,5 +97,6 @@ export const thegraphQuery = (server: McpServer, env: Partial<DotEnv>) => {
         ],
       };
     }
-  });
+    },
+  );
 };


### PR DESCRIPTION
## Summary
- expose JSON Schema `inputSchema` for all MCP tools
- add `zod-to-json-schema` dependency
- document available schemas in README

## Testing
- `bun test` *(fails: Cannot find module '@settlemint/sdk-js' from '/workspace/sdk/test/portal.e2e.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68a18da107b88332a2cc3d4d6c398121